### PR TITLE
Upgrade heatmaps with annotations and coordinated views

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A browser-local scientific visualization workspace for creating compact, publica
 - A unified Box, Violin, Beeswarm, Raincloud, Histogram, Density, and Ridge layer system with deterministic binning, KDE, quartiles, SD, SEM, Student t confidence intervals, pairing, facets, and orientation controls
 - Line uncertainty as pointwise SD, SEM, or supplied 95% CI half-widths, displayed as bars or ribbons
 - Association views spanning points, marginals, 2D density, hexbin counts, covariance ellipses, convex hulls, three-variable pair matrices, orthographic 3D, and ternary compositions, with linear, polynomial, or LOESS fits
+- Heatmaps with row/column z-scaling, Euclidean or correlation distance, average/complete/single linkage, dendrograms, reproducible cluster cuts, stable-ID annotation tracks, triangular correlations, circular layouts, and coordinated row summaries
 - Adjustable labels, dimensions, line weights, marks, grids, legends, uncertainty bars, palettes, and plot-specific parameters
 - Built-in journal-inspired and traditional Chinese color palettes
 - SVG, 600 dpi PNG, and reproducible JSON configuration export
@@ -38,6 +39,10 @@ npm run build
 ## Scientific scope
 
 The application focuses on visualization and deterministic browser-side transformations. Correlation panels can optionally calculate two-sided P values using the conventional t approximation (Pearson product-moment or Spearman rank, as labeled); they do not adjust for multiple testing. Linear confidence ribbons describe mean-response uncertainty, not prediction intervals. Other modules do not invent P values or substitute unreported statistical summaries. Users remain responsible for selecting methods appropriate to their study design and for reporting whether uncertainty represents SD, SEM, confidence intervals, or another statistic.
+
+### Heatmap data contract
+
+Heatmap matrices use the first column as a unique row identifier and all remaining columns as numeric matrix values. Optional row and column annotation tables are TSV/CSV text whose first column contains stable identifiers; they are joined by exact ID rather than row order. Declare track semantics in headers such as `batch[categorical]` or `age[continuous]`; undeclared numeric tracks are inferred as continuous with an explicit warning. Duplicate identifiers and invalid continuous declarations block rendering, while missing and extra identifiers are reported explicitly. Browser previews are capped at 250 × 100 cells for rectangular layouts and 80 × 60 for circular layouts, with an additional size-aware minimum ring-width check. Scaling, distance, linkage, cluster-cut counts, view mode, and palettes are preserved in the JSON configuration export.
 
 ## Privacy
 

--- a/src/components/ScientificAdvancedChartPreview.tsx
+++ b/src/components/ScientificAdvancedChartPreview.tsx
@@ -6,14 +6,18 @@ import {
   correlation,
   correlationPValue,
   correlationMatrix,
-  hierarchicalClusterOrder,
+  cutHierarchicalCluster,
+  hierarchicalClusterTree,
   kaplanMeier,
   matrixFromRows,
   rocCurve,
   upsetVerticalLayout,
   vennRegionLayout,
+  type HierarchicalClusterNode,
 } from "@/lib/visualization-advanced";
 import {
+  alignHeatmapAnnotations,
+  categoricalColorForIndex,
   boxStatistics,
   confidenceInterval95,
   covarianceEllipsePoints,
@@ -23,6 +27,7 @@ import {
   figureFontPresets,
   formatTick,
   getPlotDefinition,
+  heatmapLayoutMetrics,
   interpolateColor,
   journalThemes,
   kernelDensityEstimate,
@@ -40,6 +45,7 @@ import {
   type ParsedDataset,
   type PlotType,
   type VisualizationSettings,
+  type HeatmapAnnotationTrack,
 } from "@/lib/visualization-studio";
 
 type Props = {
@@ -57,10 +63,13 @@ const TEXT = "#23242A";
 
 function frameFor(type: PlotType, settings: VisualizationSettings): Frame {
   const noAxes = ["venn", "sankey", "chord", "circos", "pie", "donut", "rose", "waffle", "treemap", "sunburst", "radar", "polar-profile", "population-pyramid"].includes(type);
-  const labelHeavy = ["enrichment-bar", "survival-forest", "upset"].includes(type);
-  const hasLegend = !["box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "clustered-heatmap", "correlation-heatmap", "venn", "upset", "sankey", "chord", "circos", "treemap"].includes(type);
+  const heatmapType = ["heatmap", "clustered-heatmap", "correlation-heatmap"].includes(type);
+  const hasHeatmapAnnotationLegend = heatmapType && Boolean(settings.heatmapRowAnnotationData.trim() || settings.heatmapColumnAnnotationData.trim());
+  const labelHeavy = ["heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment-bar", "survival-forest", "upset"].includes(type);
+  const hasLegend = !["box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "heatmap", "clustered-heatmap", "correlation-heatmap", "venn", "upset", "sankey", "chord", "circos", "treemap"].includes(type);
   const compactRadialLegend = ["pie", "donut", "rose", "waffle", "sunburst", "radar", "polar-profile", "population-pyramid"].includes(type);
   const legend = hasLegend && settings.legendPosition === "right" ? (compactRadialLegend ? 110 : 145) : 0;
+  if (heatmapType) return heatmapLayoutMetrics(settings, { hasAnnotationLegend: hasHeatmapAnnotationLegend, rowAnnotationTracks: 0, columnAnnotationTracks: 0, showRowCut: false, showColumnCut: false, showRowDendrogram: false, showColumnDendrogram: false, showSidePlot: false, rowCount: 1, columnCount: 1, maxColumnLabelCharacters: 0, maxCutClusters: 0 }).frame;
   const left = noAxes ? 14 : labelHeavy ? Math.min(178, settings.width * 0.32) : 66;
   const top = settings.title ? 48 : 24;
   const bottom = hasLegend && settings.legendPosition === "bottom" ? 80 : 58;
@@ -388,43 +397,252 @@ function DistributionPlot({ type, frame, dataset, mapping, settings, colors, gri
   </>;
 }
 
-function MatrixPlot({ type, frame, dataset, settings, diverging }: { type: "clustered-heatmap" | "correlation-heatmap"; frame: Frame; dataset: ParsedDataset; settings: VisualizationSettings; diverging: [string, string, string] }) {
+function zScore(values: number[]) {
+  const average = values.reduce((sum, value) => sum + value, 0) / Math.max(1, values.length);
+  const deviation = Math.sqrt(values.reduce((sum, value) => sum + (value - average) ** 2, 0) / Math.max(1, values.length - 1)) || 1;
+  return values.map((value) => (value - average) / deviation);
+}
+
+function selectedLabelIndices(count: number, availablePixels: number, fontSize: number, density: VisualizationSettings["heatmapLabelDensity"], minimum = 2) {
+  if (density === "none") return new Set<number>();
+  if (density === "all") return new Set(Array.from({ length: count }, (_, index) => index));
+  const maximum = Math.max(minimum, Math.floor(availablePixels / Math.max(11, fontSize + 3)));
+  if (count <= maximum) return new Set(Array.from({ length: count }, (_, index) => index));
+  const step = Math.ceil(count / maximum);
+  return new Set(Array.from({ length: count }, (_, index) => index).filter((index) => index % step === 0 || index === count - 1));
+}
+
+function annotationTrackColor(track: HeatmapAnnotationTrack, value: string, colors: string[], sequential: [string, string]) {
+  if (!value) return "#F1F0ED";
+  if (track.kind === "continuous" && track.numericExtent) {
+    const numeric = parseNumericValue(value) ?? track.numericExtent[0];
+    return interpolateColor(sequential[0], sequential[1], scaleLinear(numeric, track.numericExtent, [0, 1]));
+  }
+  const categoryIndex = Math.max(0, track.categories.indexOf(value));
+  return categoricalColorForIndex(categoryIndex, colors);
+}
+
+function annularSectorPath(cx: number, cy: number, innerRadius: number, outerRadius: number, startAngle: number, endAngle: number) {
+  const point = (radius: number, angle: number) => [cx + Math.cos(angle) * radius, cy + Math.sin(angle) * radius] as const;
+  const outerStart = point(outerRadius, startAngle); const outerEnd = point(outerRadius, endAngle);
+  const innerEnd = point(innerRadius, endAngle); const innerStart = point(innerRadius, startAngle);
+  const largeArc = endAngle - startAngle > Math.PI ? 1 : 0;
+  return `M ${outerStart[0]} ${outerStart[1]} A ${outerRadius} ${outerRadius} 0 ${largeArc} 1 ${outerEnd[0]} ${outerEnd[1]} L ${innerEnd[0]} ${innerEnd[1]} A ${innerRadius} ${innerRadius} 0 ${largeArc} 0 ${innerStart[0]} ${innerStart[1]} Z`;
+}
+
+function HeatmapColorLegend({ id, x, y, width, minimum, maximum, diverging, sequential, useDiverging, label, fontSize }: { id: string; x: number; y: number; width: number; minimum: number; maximum: number; diverging: [string, string, string]; sequential: [string, string]; useDiverging: boolean; label: string; fontSize: number }) {
+  const small = Math.max(8, fontSize - 1);
+  return <g data-plot-element="heatmap-color-legend">
+    <defs><linearGradient id={id} x1="0%" x2="100%">{useDiverging ? <><stop offset="0%" stopColor={diverging[0]} /><stop offset="50%" stopColor={diverging[1]} /><stop offset="100%" stopColor={diverging[2]} /></> : <><stop offset="0%" stopColor={sequential[0]} /><stop offset="100%" stopColor={sequential[1]} /></>}</linearGradient></defs>
+    <text x={x} y={y + 7} fill={TEXT} fontSize={fontSize} fontWeight={700}>{label}</text>
+    <rect data-no-clip="true" x={x + 34} y={y} width={width} height={5} rx={1} fill={`url(#${id})`} stroke="#D7D4CE" strokeWidth={0.4} />
+    <text x={x + 34} y={y + 15} fill={TEXT} fontSize={small} textAnchor="start">{formatTick(minimum)}</text>
+    {useDiverging ? <text x={x + 34 + width / 2} y={y + 15} fill={TEXT} fontSize={small} textAnchor="middle">0</text> : null}
+    <text x={x + 34 + width} y={y + 15} fill={TEXT} fontSize={small} textAnchor="end">{formatTick(maximum)}</text>
+  </g>;
+}
+
+function HeatmapAnnotationLegend({ id, x, y, rowTracks, columnTracks, colors, sequential, fontSize }: { id: string; x: number; y: number; rowTracks: HeatmapAnnotationTrack[]; columnTracks: HeatmapAnnotationTrack[]; colors: string[]; sequential: [string, string]; fontSize: number }) {
+  let cursor = y;
+  const small = Math.max(8, fontSize - 1);
+  const rowHeight = fontSize + 3;
+  const groups = [{ target: "Rows", tracks: rowTracks }, { target: "Columns", tracks: columnTracks }];
+  const content: ReactNode[] = [];
+  groups.forEach(({ target, tracks }) => {
+    if (tracks.length === 0) return;
+    content.push(<text key={`${target}-heading`} x={x} y={cursor + fontSize} fill={TEXT} fontSize={fontSize} fontWeight={700}>{target}</text>);
+    cursor += rowHeight;
+    tracks.forEach((track, trackIndex) => {
+      content.push(<text key={`${target}-${track.name}`} x={x} y={cursor + fontSize} fill={TEXT} fontSize={fontSize} fontWeight={600}>{track.name.slice(0, 14)}</text>);
+      cursor += rowHeight;
+      if (track.kind === "continuous" && track.numericExtent) {
+        const gradientId = `${id}-${target}-${trackIndex}`.replace(/[^a-zA-Z0-9_-]/g, "-");
+        content.push(<g key={`${target}-${track.name}-scale`}><defs><linearGradient id={gradientId} x1="0%" x2="100%"><stop offset="0%" stopColor={sequential[0]} /><stop offset="100%" stopColor={sequential[1]} /></linearGradient></defs><rect data-no-clip="true" x={x} y={cursor} width={52} height={5} rx={1} fill={`url(#${gradientId})`} /><text x={x} y={cursor + rowHeight} fill={TEXT} fontSize={small}>{formatTick(track.numericExtent[0])}</text><text x={x + 52} y={cursor + rowHeight} textAnchor="end" fill={TEXT} fontSize={small}>{formatTick(track.numericExtent[1])}</text></g>);
+        cursor += rowHeight + 5;
+      } else {
+        track.categories.forEach((category, categoryIndex) => {
+          content.push(<g key={`${target}-${track.name}-${category}`}><rect data-no-clip="true" x={x} y={cursor + 1} width={7} height={7} rx={1} fill={categoricalColorForIndex(categoryIndex, colors)} /><text x={x + 11} y={cursor + fontSize} fill={TEXT} fontSize={small}>{category.slice(0, 14)}</text></g>);
+          cursor += rowHeight;
+        });
+      }
+      cursor += 3;
+    });
+  });
+  return <g data-plot-element="heatmap-annotation-legend" aria-label="Heatmap annotation legend">{content}</g>;
+}
+
+function HeatmapCutLegend({ x, y, rowClusters, columnClusters, colors, fontSize }: { x: number; y: number; rowClusters: number; columnClusters: number; colors: string[]; fontSize: number }) {
+  const rows = [{ label: "R", count: rowClusters }, { label: "C", count: columnClusters }].filter(({ count }) => count > 1);
+  if (rows.length === 0) return null;
+  const readable = Math.max(8, fontSize);
+  const rowHeight = readable + 2;
+  const itemStep = Math.max(13, readable * 1.15);
+  return <g data-plot-element="heatmap-cut-legend" aria-label="Cluster cut legend">{rows.map(({ label, count }, rowIndex) => <g key={label} transform={`translate(${x} ${y + rowIndex * rowHeight})`}><text x={0} y={readable} fill={TEXT} fontSize={readable} fontWeight={700}>{label}</text>{Array.from({ length: count }, (_, clusterIndex) => <g key={clusterIndex}><rect data-no-clip="true" x={12 + clusterIndex * itemStep} y={1} width={8} height={8} rx={1} fill={categoricalColorForIndex(clusterIndex, colors)} /><text x={21 + clusterIndex * itemStep} y={readable} fill={TEXT} fontSize={readable}>{clusterIndex + 1}</text></g>)}</g>)}</g>;
+}
+
+function MatrixPlot({ type, dataset, settings, diverging, sequential, colors }: { type: "heatmap" | "clustered-heatmap" | "correlation-heatmap"; frame: Frame; dataset: ParsedDataset; settings: VisualizationSettings; diverging: [string, string, string]; sequential: [string, string]; colors: string[] }) {
   const labelColumn = dataset.headers[0];
   const sourceColumns = dataset.headers.slice(1);
   const source = matrixFromRows(dataset.rows, sourceColumns);
-  let rowLabels: string[];
-  let columnLabels: string[];
-  let matrix: number[][];
+  let sourceRowLabels = dataset.rows.map((row) => row[labelColumn]);
+  const sourceColumnLabels = [...sourceColumns];
+  let sourceMatrix: number[][];
   if (type === "correlation-heatmap") {
-    matrix = correlationMatrix(source, settings.correlationMethod);
-    rowLabels = [...sourceColumns];
-    columnLabels = [...sourceColumns];
-  } else {
-    matrix = settings.heatmapScale === "row" ? source.map((row) => { const avg = row.reduce((sum, value) => sum + value, 0) / row.length; const sd = Math.sqrt(row.reduce((sum, value) => sum + (value - avg) ** 2, 0) / Math.max(1, row.length - 1)) || 1; return row.map((value) => (value - avg) / sd); }) : source;
-    rowLabels = dataset.rows.map((row) => row[labelColumn]);
-    columnLabels = [...sourceColumns];
+    sourceMatrix = correlationMatrix(source, settings.correlationMethod);
+    sourceRowLabels = [...sourceColumns];
+  } else if (settings.heatmapScale === "row") {
+    sourceMatrix = source.map(zScore);
+  } else if (settings.heatmapScale === "column") {
+    const columns = sourceColumns.map((_, columnIndex) => zScore(source.map((row) => row[columnIndex])));
+    sourceMatrix = source.map((_, rowIndex) => columns.map((column) => column[rowIndex]));
+  } else sourceMatrix = source;
+
+  const allowsClustering = type !== "heatmap";
+  const linkedCorrelationClustering = type === "correlation-heatmap" ? settings.clusterRows && settings.clusterColumns : null;
+  const effectiveClusterRows = type === "correlation-heatmap" ? Boolean(linkedCorrelationClustering) : settings.clusterRows;
+  const effectiveClusterColumns = type === "correlation-heatmap" ? Boolean(linkedCorrelationClustering) : settings.clusterColumns;
+  const rowTree = allowsClustering && effectiveClusterRows ? hierarchicalClusterTree(sourceMatrix, settings.heatmapDistance, settings.heatmapLinkage) : null;
+  const sourceColumnVectors = sourceColumnLabels.map((_, columnIndex) => sourceMatrix.map((row) => row[columnIndex]));
+  const columnTree = allowsClustering && effectiveClusterColumns ? hierarchicalClusterTree(sourceColumnVectors, settings.heatmapDistance, settings.heatmapLinkage) : null;
+  let rowOrder = rowTree?.order ?? sourceMatrix.map((_, index) => index);
+  let columnOrder = columnTree?.order ?? sourceColumnLabels.map((_, index) => index);
+  let displayedRowTree = rowTree;
+  let displayedColumnTree = columnTree;
+  if (type === "correlation-heatmap" && (rowTree || columnTree)) {
+    const sharedTree = rowTree ?? columnTree;
+    rowOrder = sharedTree?.order ?? rowOrder;
+    columnOrder = rowOrder;
+    displayedRowTree = effectiveClusterRows ? sharedTree : null;
+    displayedColumnTree = effectiveClusterColumns ? sharedTree : null;
   }
-  const rowOrder = settings.clusterRows ? hierarchicalClusterOrder(matrix) : matrix.map((_, index) => index);
-  const columnVectors = columnLabels.map((_, column) => matrix.map((row) => row[column]));
-  const columnOrder = settings.clusterColumns ? hierarchicalClusterOrder(columnVectors) : columnLabels.map((_, index) => index);
-  if (type === "correlation-heatmap" && (settings.clusterRows || settings.clusterColumns)) {
-    const shared = settings.clusterRows ? rowOrder : columnOrder;
-    rowLabels = shared.map((index) => rowLabels[index]);
-    columnLabels = shared.map((index) => columnLabels[index]);
-    matrix = shared.map((row) => shared.map((column) => matrix[row][column]));
-  } else {
-    rowLabels = rowOrder.map((index) => rowLabels[index]);
-    columnLabels = columnOrder.map((index) => columnLabels[index]);
-    matrix = rowOrder.map((row) => columnOrder.map((column) => matrix[row][column]));
+  const rowLabels = rowOrder.map((index) => sourceRowLabels[index]);
+  const columnLabels = columnOrder.map((index) => sourceColumnLabels[index]);
+  const matrix = rowOrder.map((rowIndex) => columnOrder.map((columnIndex) => sourceMatrix[rowIndex][columnIndex]));
+  const sidePlotMatrix = type === "correlation-heatmap" ? matrix : rowOrder.map((rowIndex) => columnOrder.map((columnIndex) => source[rowIndex][columnIndex]));
+  const rowAnnotations = alignHeatmapAnnotations(settings.heatmapRowAnnotationData, sourceRowLabels, "row").tracks;
+  const columnAnnotations = alignHeatmapAnnotations(settings.heatmapColumnAnnotationData, sourceColumnLabels, "column").tracks;
+  const rowCutCount = settings.heatmapRowClusters;
+  const columnCutCount = type === "correlation-heatmap" ? rowCutCount : settings.heatmapColumnClusters;
+  const rowClusterAssignments = cutHierarchicalCluster(displayedRowTree, rowCutCount);
+  const columnClusterAssignments = cutHierarchicalCluster(displayedColumnTree, columnCutCount);
+  const showRowCut = Boolean(displayedRowTree && rowCutCount > 1);
+  const showColumnCut = Boolean(displayedColumnTree && columnCutCount > 1);
+  const flatValues = matrix.flat();
+  const rawMinimum = Math.min(...flatValues); const rawMaximum = Math.max(...flatValues);
+  const absoluteMaximum = type === "correlation-heatmap" ? 1 : Math.max(Math.abs(rawMinimum), Math.abs(rawMaximum), Number.EPSILON);
+  const useDiverging = type === "correlation-heatmap" || settings.heatmapScale !== "none" || settings.heatmapColorMode === "diverging";
+  const colorMinimum = useDiverging ? -absoluteMaximum : rawMinimum;
+  const colorMaximum = useDiverging ? absoluteMaximum : rawMaximum;
+  const colorScaleLabel = type === "correlation-heatmap" ? (settings.correlationMethod === "spearman" ? "ρ" : "r") : settings.heatmapScale === "none" ? "Value" : "z";
+  const fillFor = (value: number) => useDiverging
+    ? divergingColor(diverging[0], diverging[1], diverging[2], scaleLinear(value, [-absoluteMaximum, absoluteMaximum], [0, 1]))
+    : interpolateColor(sequential[0], sequential[1], scaleLinear(value, [rawMinimum, rawMaximum === rawMinimum ? rawMinimum + 1 : rawMaximum], [0, 1]));
+  const visibleCell = (rowIndex: number, columnIndex: number) => settings.heatmapDisplay === "circular" || type !== "correlation-heatmap" || settings.heatmapTriangle === "full" || (settings.heatmapTriangle === "lower" ? rowIndex >= columnIndex : rowIndex <= columnIndex);
+  const showDendrograms = allowsClustering && settings.heatmapShowDendrograms && settings.heatmapDisplay === "rectangular";
+  const layout = heatmapLayoutMetrics(settings, {
+    hasAnnotationLegend: rowAnnotations.length > 0 || columnAnnotations.length > 0,
+    rowAnnotationTracks: rowAnnotations.length,
+    columnAnnotationTracks: columnAnnotations.length,
+    showRowCut,
+    showColumnCut,
+    showRowDendrogram: Boolean(showDendrograms && displayedRowTree),
+    showColumnDendrogram: Boolean(showDendrograms && displayedColumnTree),
+    showSidePlot: settings.heatmapDisplay === "rectangular" && settings.heatmapShowSidePlot,
+    rowCount: rowLabels.length,
+    columnCount: columnLabels.length,
+    maxColumnLabelCharacters: Math.max(0, ...columnLabels.map((label) => label.length)),
+    maxCutClusters: Math.max(showRowCut ? Math.min(rowCutCount, rowLabels.length) : 0, showColumnCut ? Math.min(columnCutCount, columnLabels.length) : 0),
+  });
+  const frame = layout.frame;
+  const legendFontSize = Math.max(8, settings.legendSize);
+
+  if (settings.heatmapDisplay === "circular") {
+    const cx = frame.left + frame.plotWidth / 2; const cy = frame.top + frame.plotHeight / 2;
+    const outerRadius = Math.max(1, layout.circularOuterRadius);
+    const innerRadius = Math.max(0.5, Math.min(outerRadius - 0.5, layout.circularInnerRadius));
+    const ringWidth = Math.max(0.1, layout.circularRingWidth);
+    const sector = Math.PI * 2 / Math.max(1, columnLabels.length);
+    const columnLabelIndices = selectedLabelIndices(columnLabels.length, outerRadius * Math.PI * 2, settings.tickSize * 4, settings.heatmapLabelDensity);
+    const rowLabelIndices = selectedLabelIndices(rowLabels.length, layout.circularRingListAvailableHeight, legendFontSize, settings.heatmapLabelDensity, 1);
+    return <g data-plot-data data-plot-family="circular-heatmap">
+      {matrix.map((row, rowIndex) => row.map((value, columnIndex) => {
+        if (!visibleCell(rowIndex, columnIndex)) return null;
+        const start = -Math.PI / 2 + columnIndex * sector; const end = start + sector;
+        return <path key={`${rowIndex}-${columnIndex}`} data-plot-element="heatmap-cell" d={annularSectorPath(cx, cy, innerRadius + rowIndex * ringWidth, innerRadius + (rowIndex + 1) * ringWidth + 0.15, start, end)} fill={fillFor(value)} stroke="#FFFFFF" strokeWidth={0.18}><title>{`${rowLabels[rowIndex]} × ${columnLabels[columnIndex]}: ${formatTick(value)}`}</title></path>;
+      }))}
+      {columnAnnotations.map((track, trackIndex) => columnLabels.map((label, columnIndex) => { const start = -Math.PI / 2 + columnIndex * sector; return <path key={`${track.name}-${label}`} data-annotation-target="column" data-annotation-track={track.name} d={annularSectorPath(cx, cy, outerRadius + trackIndex * 5 + 1, outerRadius + (trackIndex + 1) * 5, start, start + sector)} fill={annotationTrackColor(track, track.values.get(label) ?? "", colors, sequential)} stroke="#FFFFFF" strokeWidth={0.2}><title>{`${track.name} · ${label}: ${track.values.get(label) || "missing"}`}</title></path>; }))}
+      {rowAnnotations.map((track, trackIndex) => rowLabels.map((label, rowIndex) => <path key={`${track.name}-${label}`} data-annotation-target="row" data-annotation-track={track.name} d={annularSectorPath(cx, cy, innerRadius + rowIndex * ringWidth, innerRadius + (rowIndex + 1) * ringWidth, -Math.PI / 2 - 0.055 * (trackIndex + 1), -Math.PI / 2 - 0.055 * trackIndex)} fill={annotationTrackColor(track, track.values.get(label) ?? "", colors, sequential)}><title>{`${track.name} · ${label}: ${track.values.get(label) || "missing"}`}</title></path>))}
+      {showColumnCut ? columnLabels.map((label, columnIndex) => { const sourceIndex = sourceColumnLabels.indexOf(label); const start = -Math.PI / 2 + columnIndex * sector; return <path key={`column-cut-${label}`} data-cluster-cut="column" d={annularSectorPath(cx, cy, outerRadius - 3, outerRadius, start, start + sector)} fill={categoricalColorForIndex(columnClusterAssignments[sourceIndex], colors)} />; }) : null}
+      {showRowCut ? rowLabels.map((label, rowIndex) => { const sourceIndex = sourceRowLabels.indexOf(label); return <path key={`row-cut-${label}`} data-cluster-cut="row" d={annularSectorPath(cx, cy, innerRadius + rowIndex * ringWidth, innerRadius + (rowIndex + 1) * ringWidth, -Math.PI / 2, -Math.PI / 2 + 0.05)} fill={categoricalColorForIndex(rowClusterAssignments[sourceIndex], colors)} />; }) : null}
+      {columnLabels.map((label, index) => { if (!columnLabelIndices.has(index)) return null; const angle = -Math.PI / 2 + (index + 0.5) * sector; const radius = outerRadius + columnAnnotations.length * 5 + 10; const x = cx + Math.cos(angle) * radius; const y = cy + Math.sin(angle) * radius; const flip = Math.cos(angle) < 0; const degrees = angle * 180 / Math.PI + (flip ? 180 : 0); return <text key={label} x={x} y={y} transform={`rotate(${degrees} ${x} ${y})`} textAnchor={flip ? "end" : "start"} dominantBaseline="middle" fill={TEXT} fontSize={settings.tickSize}>{label.slice(0, 12)}</text>; })}
+      {settings.heatmapLabelDensity !== "none" ? <><text x={4} y={frame.top + legendFontSize} fill={TEXT} fontSize={legendFontSize} fontWeight={700}>Rings · inner → outer</text>{rowLabels.map((label, index) => rowLabelIndices.has(index) ? <text key={`ring-${label}`} x={4} y={frame.top + legendFontSize * 2 + 4 + [...rowLabelIndices].indexOf(index) * (legendFontSize + 3)} fill={TEXT} fontSize={legendFontSize}>{`${index + 1} · ${label.slice(0, 11)}`}</text> : null)}</> : null}
+      <HeatmapColorLegend id={`heatmap-scale-${type}`} x={cx - 42} y={frame.top + frame.plotHeight - 17} width={48} minimum={colorMinimum} maximum={colorMaximum} diverging={diverging} sequential={sequential} useDiverging={useDiverging} label={colorScaleLabel} fontSize={legendFontSize} />
+      <HeatmapCutLegend x={frame.left} y={frame.top} rowClusters={showRowCut ? Math.min(rowCutCount, rowLabels.length) : 0} columnClusters={showColumnCut ? Math.min(columnCutCount, columnLabels.length) : 0} colors={colors} fontSize={legendFontSize} />
+      {(rowAnnotations.length > 0 || columnAnnotations.length > 0) ? <HeatmapAnnotationLegend id={`heatmap-annotations-${type}`} x={frame.left + frame.plotWidth + 10} y={frame.top} rowTracks={rowAnnotations} columnTracks={columnAnnotations} colors={colors} sequential={sequential} fontSize={legendFontSize} /> : null}
+      <circle cx={cx} cy={cy} r={outerRadius} fill="none" stroke={TEXT} strokeWidth={0.7} />
+    </g>;
   }
-  const max = type === "correlation-heatmap" ? 1 : Math.max(...matrix.flat().map(Math.abs), 1);
-  const cellWidth = frame.plotWidth / Math.max(1, columnLabels.length);
-  const cellHeight = frame.plotHeight / Math.max(1, rowLabels.length);
-  return <g>
-    {matrix.map((row, rowIndex) => row.map((value, columnIndex) => <rect key={`${rowIndex}-${columnIndex}`} x={frame.left + columnIndex * cellWidth} y={frame.top + rowIndex * cellHeight} width={cellWidth + 0.2} height={cellHeight + 0.2} fill={divergingColor(diverging[0], diverging[1], diverging[2], scaleLinear(value, [-max, max], [0, 1]))} />))}
-    {rowLabels.slice(0, Math.floor(frame.plotHeight / Math.max(10, settings.tickSize + 2))).map((label, index) => <text key={label} x={frame.left - 7} y={frame.top + (index + 0.68) * cellHeight} textAnchor="end" fill={TEXT} fontSize={settings.tickSize}>{label.slice(0, 12)}</text>)}
-    {columnLabels.map((label, index) => <text key={label} x={frame.left + (index + 0.5) * cellWidth} y={frame.top + frame.plotHeight + 8} textAnchor="end" fill={TEXT} fontSize={settings.tickSize} transform={`rotate(-45 ${frame.left + (index + 0.5) * cellWidth} ${frame.top + frame.plotHeight + 8})`}>{label.slice(0, 12)}</text>)}
-    <rect x={frame.left} y={frame.top} width={frame.plotWidth} height={frame.plotHeight} fill="none" stroke={TEXT} strokeWidth={0.8} />
+
+  const { rowTrackWidth, columnTrackHeight, rowDendrogramWidth, columnDendrogramHeight, sidePlotWidth, colorLegendHeight } = layout;
+  const matrixLeft = frame.left + rowDendrogramWidth + rowTrackWidth;
+  const matrixTop = frame.top + colorLegendHeight + columnDendrogramHeight + columnTrackHeight;
+  const matrixWidth = Math.max(1, layout.matrixWidth);
+  const matrixHeight = Math.max(1, layout.matrixHeight);
+  const cellWidth = matrixWidth / Math.max(1, columnLabels.length);
+  const cellHeight = matrixHeight / Math.max(1, rowLabels.length);
+  const rowLabelIndices = selectedLabelIndices(rowLabels.length, matrixHeight, settings.tickSize, settings.heatmapLabelDensity);
+  const columnLabelIndices = selectedLabelIndices(columnLabels.length, matrixWidth, settings.tickSize * 4, settings.heatmapLabelDensity);
+  const showValues = settings.heatmapShowValues && cellWidth >= 18 && cellHeight >= 12 && matrix.length * columnLabels.length <= 225;
+
+  const dendrogramSegments = (tree: HierarchicalClusterNode | null, orientation: "row" | "column") => {
+    if (!tree) return [] as ReactNode[];
+    const maxHeight = Math.max(tree.height, Number.EPSILON);
+    const originalOrder = orientation === "row" ? rowOrder : columnOrder;
+    const leafPosition = new Map(originalOrder.map((originalIndex, index) => [originalIndex, orientation === "row" ? matrixTop + (index + 0.5) * cellHeight : matrixLeft + (index + 0.5) * cellWidth]));
+    const segments: ReactNode[] = [];
+    const visit = (node: HierarchicalClusterNode): [number, number] => {
+      if (!node.left || !node.right) {
+        const position = leafPosition.get(node.members[0]) ?? 0;
+        return orientation === "row" ? [matrixLeft - rowTrackWidth, position] : [position, matrixTop - columnTrackHeight];
+      }
+      const left = visit(node.left); const right = visit(node.right);
+      if (orientation === "row") {
+        const x = matrixLeft - rowTrackWidth - node.height / maxHeight * rowDendrogramWidth;
+        segments.push(<path key={node.id} data-plot-element="dendrogram" data-dendrogram-axis="row" d={`M ${left[0]} ${left[1]} H ${x} V ${right[1]} H ${right[0]}`} fill="none" stroke={TEXT} strokeWidth={0.7} />);
+        return [x, (left[1] + right[1]) / 2];
+      }
+      const y = matrixTop - columnTrackHeight - node.height / maxHeight * columnDendrogramHeight;
+      segments.push(<path key={node.id} data-plot-element="dendrogram" data-dendrogram-axis="column" d={`M ${left[0]} ${left[1]} V ${y} H ${right[0]} V ${right[1]}`} fill="none" stroke={TEXT} strokeWidth={0.7} />);
+      return [(left[0] + right[0]) / 2, y];
+    };
+    visit(tree);
+    return segments;
+  };
+
+  const rowSummaries = sidePlotMatrix.map((row) => {
+    const average = row.reduce((sum, value) => sum + value, 0) / Math.max(1, row.length);
+    if (settings.heatmapSidePlotStatistic === "sd") return Math.sqrt(row.reduce((sum, value) => sum + (value - average) ** 2, 0) / Math.max(1, row.length - 1));
+    if (settings.heatmapSidePlotStatistic === "range") return Math.max(...row) - Math.min(...row);
+    return average;
+  });
+  const summaryExtent = [Math.min(0, ...rowSummaries), Math.max(0, ...rowSummaries)] as [number, number];
+  const safeSummaryExtent: [number, number] = summaryExtent[0] === summaryExtent[1] ? [summaryExtent[0], summaryExtent[0] + 1] : summaryExtent;
+  const sideZero = scaleLinear(0, safeSummaryExtent, [matrixLeft + matrixWidth + 4, matrixLeft + matrixWidth + sidePlotWidth - 4]);
+  return <g data-plot-data data-plot-family="rectangular-heatmap">
+    <HeatmapColorLegend id={`heatmap-scale-${type}`} x={matrixLeft} y={frame.top} width={Math.max(28, Math.min(64, matrixWidth - 36))} minimum={colorMinimum} maximum={colorMaximum} diverging={diverging} sequential={sequential} useDiverging={useDiverging} label={colorScaleLabel} fontSize={legendFontSize} />
+    <HeatmapCutLegend x={matrixLeft} y={frame.top + 17} rowClusters={showRowCut ? Math.min(rowCutCount, rowLabels.length) : 0} columnClusters={showColumnCut ? Math.min(columnCutCount, columnLabels.length) : 0} colors={colors} fontSize={legendFontSize} />
+    {(rowAnnotations.length > 0 || columnAnnotations.length > 0) ? <HeatmapAnnotationLegend id={`heatmap-annotations-${type}`} x={frame.left + frame.plotWidth + 10} y={frame.top} rowTracks={rowAnnotations} columnTracks={columnAnnotations} colors={colors} sequential={sequential} fontSize={legendFontSize} /> : null}
+    {dendrogramSegments(displayedRowTree, "row")}
+    {dendrogramSegments(displayedColumnTree, "column")}
+    {matrix.map((row, rowIndex) => row.map((value, columnIndex) => visibleCell(rowIndex, columnIndex) ? <g key={`${rowIndex}-${columnIndex}`}><rect data-plot-element="heatmap-cell" x={matrixLeft + columnIndex * cellWidth} y={matrixTop + rowIndex * cellHeight} width={cellWidth + 0.2} height={cellHeight + 0.2} fill={fillFor(value)}><title>{`${rowLabels[rowIndex]} × ${columnLabels[columnIndex]}: ${formatTick(value)}`}</title></rect>{showValues ? <text x={matrixLeft + (columnIndex + 0.5) * cellWidth} y={matrixTop + (rowIndex + 0.5) * cellHeight + settings.tickSize * 0.32} textAnchor="middle" fill={TEXT} fontSize={Math.min(settings.tickSize, cellHeight * 0.62)}>{formatTick(value)}</text> : null}</g> : null))}
+    {rowAnnotations.map((track, trackIndex) => rowLabels.map((label, rowIndex) => <rect key={`${track.name}-${label}`} data-annotation-target="row" data-annotation-track={track.name} x={matrixLeft - 6 * (trackIndex + 1)} y={matrixTop + rowIndex * cellHeight} width={5.5} height={cellHeight + 0.15} fill={annotationTrackColor(track, track.values.get(label) ?? "", colors, sequential)}><title>{`${track.name} · ${label}: ${track.values.get(label) || "missing"}`}</title></rect>))}
+    {columnAnnotations.map((track, trackIndex) => columnLabels.map((label, columnIndex) => <rect key={`${track.name}-${label}`} data-annotation-target="column" data-annotation-track={track.name} x={matrixLeft + columnIndex * cellWidth} y={matrixTop - 6 * (trackIndex + 1)} width={cellWidth + 0.15} height={5.5} fill={annotationTrackColor(track, track.values.get(label) ?? "", colors, sequential)}><title>{`${track.name} · ${label}: ${track.values.get(label) || "missing"}`}</title></rect>))}
+    {showRowCut ? rowLabels.map((label, rowIndex) => { const originalIndex = sourceRowLabels.indexOf(label); return <rect key={`row-cut-${label}`} data-cluster-cut="row" x={matrixLeft - rowTrackWidth} y={matrixTop + rowIndex * cellHeight} width={5.5} height={cellHeight + 0.15} fill={categoricalColorForIndex(rowClusterAssignments[originalIndex], colors)} />; }) : null}
+    {showColumnCut ? columnLabels.map((label, columnIndex) => { const originalIndex = sourceColumnLabels.indexOf(label); return <rect key={`column-cut-${label}`} data-cluster-cut="column" x={matrixLeft + columnIndex * cellWidth} y={matrixTop - columnTrackHeight} width={cellWidth + 0.15} height={5.5} fill={categoricalColorForIndex(columnClusterAssignments[originalIndex], colors)} />; }) : null}
+    {rowLabels.map((label, index) => rowLabelIndices.has(index) ? <text key={label} x={frame.left - 6} y={matrixTop + (index + 0.68) * cellHeight} textAnchor="end" fill={TEXT} fontSize={settings.tickSize}>{label.slice(0, 12)}</text> : null)}
+    {columnLabels.map((label, index) => columnLabelIndices.has(index) ? <text key={label} x={matrixLeft + (index + 0.5) * cellWidth} y={matrixTop + matrixHeight + 8} textAnchor="end" fill={TEXT} fontSize={settings.tickSize} transform={`rotate(-45 ${matrixLeft + (index + 0.5) * cellWidth} ${matrixTop + matrixHeight + 8})`}>{label.slice(0, 12)}</text> : null)}
+    {settings.heatmapShowSidePlot ? <g data-plot-element="heatmap-side-plot"><line x1={sideZero} x2={sideZero} y1={matrixTop} y2={matrixTop + matrixHeight} stroke={TEXT} strokeWidth={0.7} />{rowSummaries.map((value, rowIndex) => { const x = scaleLinear(value, safeSummaryExtent, [matrixLeft + matrixWidth + 4, matrixLeft + matrixWidth + sidePlotWidth - 4]); return <rect key={rowLabels[rowIndex]} x={Math.min(x, sideZero)} y={matrixTop + rowIndex * cellHeight + cellHeight * 0.2} width={Math.max(0.7, Math.abs(x - sideZero))} height={Math.max(0.7, cellHeight * 0.6)} fill={colors[0]} fillOpacity={0.78}><title>{`${settings.heatmapSidePlotStatistic}: ${formatTick(value)}`}</title></rect>; })}<text x={matrixLeft + matrixWidth + sidePlotWidth / 2} y={matrixTop - 5} textAnchor="middle" fill={TEXT} fontSize={Math.max(8, settings.tickSize - 2)}>{settings.heatmapSidePlotStatistic.toUpperCase()}</text></g> : null}
+    <rect x={matrixLeft} y={matrixTop} width={matrixWidth} height={matrixHeight} fill="none" stroke={TEXT} strokeWidth={0.8} />
   </g>;
 }
 
@@ -757,7 +975,7 @@ export function ScientificAdvancedChartPreview({ svgRef, type, dataset, mapping,
   else if (type === "area") content = <AreaPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (type === "lollipop") content = <LollipopPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (["box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge"].includes(type)) content = <DistributionPlot type={type as DistributionPlotType} frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
-  else if (type === "clustered-heatmap" || type === "correlation-heatmap") content = <MatrixPlot type={type} frame={frame} dataset={dataset} settings={settings} diverging={diverging} />;
+  else if (type === "heatmap" || type === "clustered-heatmap" || type === "correlation-heatmap") content = <MatrixPlot type={type} frame={frame} dataset={dataset} settings={settings} diverging={diverging} sequential={sequential} colors={colors} />;
   else if (type === "enrichment-bar") content = <EnrichmentBar frame={frame} dataset={dataset} mapping={mapping} settings={settings} sequential={sequential} gridColor={theme.grid} />;
   else if (type === "gsea") content = <GseaPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (type === "km") content = <KmPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
@@ -777,7 +995,7 @@ export function ScientificAdvancedChartPreview({ svgRef, type, dataset, mapping,
   return <svg ref={svgRef} xmlns="http://www.w3.org/2000/svg" viewBox={`0 0 ${frame.width} ${frame.height}`} width={frame.width} height={frame.height} role="img" data-plot-renderer="advanced" data-chart-text-color={TEXT} aria-label={`${definition.name} scientific figure preview`} style={{ fontFamily: figureFontPresets[settings.fontFamily].family, background: "white", maxWidth: "100%", height: "auto" }}>
     <title>{settings.title || `${definition.name} figure`}</title><desc>{definition.summary} Generated in LabNest Visualization Studio.</desc><rect width={frame.width} height={frame.height} fill="#FFFFFF" />
     <defs><clipPath id={`plot-area-${type}`}><rect x={frame.left} y={frame.top} width={frame.plotWidth} height={frame.plotHeight} /></clipPath></defs>
-    <style>{`[data-plot-data] path,[data-plot-data] circle,[data-plot-data] rect,[data-plot-data] line,[data-plot-data] polyline,[data-plot-data] polygon,[data-plot-data] text[data-plot-label]{clip-path:url(#plot-area-${type})}`}</style>
+    <style>{`[data-plot-data] path:not([data-no-clip]),[data-plot-data] circle:not([data-no-clip]),[data-plot-data] rect:not([data-no-clip]),[data-plot-data] line:not([data-no-clip]),[data-plot-data] polyline:not([data-no-clip]),[data-plot-data] polygon:not([data-no-clip]),[data-plot-data] text[data-plot-label]{clip-path:url(#plot-area-${type})}`}</style>
     {settings.title ? <text x={frame.left} y={24} fill={TEXT} fontSize={settings.titleSize} fontWeight={700}>{settings.title}</text> : null}
     {content}
   </svg>;

--- a/src/components/VisualizationStudio.tsx
+++ b/src/components/VisualizationStudio.tsx
@@ -285,6 +285,23 @@ function TextControl({ label, value, onChange, placeholder }: { label: string; v
   );
 }
 
+function TextareaControl({ label, value, onChange, placeholder, hint }: { label: string; value: string; onChange: (value: string) => void; placeholder?: string; hint?: string }) {
+  return (
+    <label className="grid gap-1 text-xs text-graphite">
+      <span>{label}</span>
+      <textarea
+        aria-label={label}
+        value={value}
+        placeholder={placeholder}
+        spellCheck={false}
+        onChange={(event) => onChange(event.target.value)}
+        className="focus-ring min-h-20 resize-y rounded-[7px] border border-hairline bg-[#FBFBF9] px-2.5 py-2 font-mono text-[10px] leading-4 text-ink placeholder:text-muted"
+      />
+      {hint ? <span className="text-[10px] leading-4 text-muted">{hint}</span> : null}
+    </label>
+  );
+}
+
 function SelectControl({ label, value, onChange, children }: { label: string; value: string; onChange: (value: string) => void; children: ReactNode }) {
   return (
     <label className="grid gap-1 text-xs text-graphite">
@@ -419,6 +436,7 @@ export function VisualizationStudio() {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const stickyHeaderRef = useRef<HTMLDivElement | null>(null);
   const previewCardRef = useRef<HTMLDivElement | null>(null);
+  const parameterScrollRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
@@ -557,10 +575,13 @@ export function VisualizationStudio() {
       xLabel: "",
       yLabel: "",
       swapAxes: false,
+      clusterColumns: nextType === "correlation-heatmap" ? current.clusterRows : current.clusterColumns,
+      heatmapColumnClusters: nextType === "correlation-heatmap" ? current.heatmapRowClusters : current.heatmapColumnClusters,
       compositionLabelMode: nextType === "rose" ? "value" : current.compositionLabelMode,
       legendPosition: (["heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment", "enrichment-bar", "venn", "upset", "sankey", "chord", "circos"] as PlotType[]).includes(nextType) && current.legendPosition === "bottom" ? "right" : current.legendPosition,
     }, nextType));
     window.requestAnimationFrame(() => {
+      if (parameterScrollRef.current) parameterScrollRef.current.scrollTop = 0;
       previewCardRef.current?.scrollIntoView({ behavior: "auto", block: "start" });
     });
   };
@@ -939,7 +960,7 @@ export function VisualizationStudio() {
               const plotResetSettings = plotType === "rose" ? { ...resetSettings, compositionLabelMode: "value" as const } : resetSettings;
               setSettings(settingsForDistributionPreset(plotResetSettings, plotType));
             }}><RotateCcw className="h-3.5 w-3.5" aria-hidden />Reset</Button>} />
-            <CardBody className="space-y-4 p-4 xl:min-h-0 xl:flex-1 xl:overflow-y-auto xl:[scrollbar-gutter:stable]">
+            <CardBody ref={parameterScrollRef} className="space-y-4 p-4 xl:min-h-0 xl:flex-1 xl:overflow-y-auto xl:[scrollbar-gutter:stable]">
               <ControlGroup title="Labels">
                 <TextControl label="Title" value={settings.title} onChange={(value) => updateSetting("title", value)} placeholder={`${definition.name} title`} />
               {hasSetting("xLabel") ? <TextControl label="X-axis label" value={settings.xLabel} onChange={(value) => updateSetting("xLabel", value)} /> : null}
@@ -1031,7 +1052,32 @@ export function VisualizationStudio() {
             {plotType === "correlation-heatmap" ? <ControlGroup title="Correlation"><SelectControl label="Method" value={settings.correlationMethod} onChange={(value) => updateSetting("correlationMethod", value as VisualizationSettings["correlationMethod"])}><option value="pearson">Pearson</option><option value="spearman">Spearman</option></SelectControl><p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Each matrix cell is calculated from paired complete observations. This view reports coefficients, not inferential P values.</p></ControlGroup> : null}
             {plotType === "quadrant" ? <ControlGroup title="Quadrant thresholds"><RangeControl label="X threshold" value={settings.xThreshold} minimum={-10} maximum={10} step={0.1} onChange={(value) => updateSetting("xThreshold", value)} /><RangeControl label="Y threshold" value={settings.yThreshold} minimum={-10} maximum={10} step={0.1} onChange={(value) => updateSetting("yThreshold", value)} /></ControlGroup> : null}
             {plotType === "errorbar" ? <ControlGroup title="Error bars"><RangeControl label="Error line" value={settings.errorBarLineWidth} minimum={0.8} maximum={3} step={0.1} unit=" px" onChange={(value) => updateSetting("errorBarLineWidth", value)} /><RangeControl label="Cap width" value={settings.errorBarCapSize} minimum={4} maximum={30} step={1} unit=" px" onChange={(value) => updateSetting("errorBarCapSize", value)} /><p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">The mapped error column must already contain SD or SEM. Record which statistic you used in the title, axis, caption, or exported config.</p></ControlGroup> : null}
-            {(["heatmap", "clustered-heatmap", "correlation-heatmap"] as PlotType[]).includes(plotType) ? <ControlGroup title="Heatmap">{plotType !== "correlation-heatmap" ? <SelectControl label="Scaling" value={settings.heatmapScale} onChange={(value) => updateSetting("heatmapScale", value as VisualizationSettings["heatmapScale"])}><option value="row">Row z-score</option><option value="none">Raw values</option></SelectControl> : null}{plotType !== "heatmap" ? <><ToggleControl label="Cluster rows" checked={settings.clusterRows} onChange={(value) => updateSetting("clusterRows", value)} /><ToggleControl label="Cluster columns" checked={settings.clusterColumns} onChange={(value) => updateSetting("clusterColumns", value)} /><p className="text-[11px] leading-4 text-muted">Deterministic Euclidean average-linkage ordering is used for the preview.</p></> : null}</ControlGroup> : null}
+            {(["heatmap", "clustered-heatmap", "correlation-heatmap"] as PlotType[]).includes(plotType) ? <>
+              <ControlGroup title="Heatmap view">
+                <SelectControl label="Layout" value={settings.heatmapDisplay} onChange={(value) => updateSetting("heatmapDisplay", value as VisualizationSettings["heatmapDisplay"])}><option value="rectangular">Rectangular matrix</option><option value="circular">Circular heatmap</option></SelectControl>
+                {plotType === "correlation-heatmap" && settings.heatmapDisplay === "rectangular" ? <SelectControl label="Correlation cells" value={settings.heatmapTriangle} onChange={(value) => updateSetting("heatmapTriangle", value as VisualizationSettings["heatmapTriangle"])}><option value="lower">Lower triangle</option><option value="upper">Upper triangle</option><option value="full">Full matrix</option></SelectControl> : null}
+                {plotType !== "correlation-heatmap" ? <SelectControl label="Scaling" value={settings.heatmapScale} onChange={(value) => updateSetting("heatmapScale", value as VisualizationSettings["heatmapScale"])}><option value="row">Row z-score</option><option value="column">Column z-score</option><option value="none">Raw values</option></SelectControl> : null}
+                {plotType !== "correlation-heatmap" && settings.heatmapScale === "none" ? <SelectControl label="Color scale" value={settings.heatmapColorMode} onChange={(value) => updateSetting("heatmapColorMode", value as VisualizationSettings["heatmapColorMode"])}><option value="sequential">Sequential low → high</option><option value="diverging">Diverging around zero</option></SelectControl> : null}
+                <SelectControl label="Label density" value={settings.heatmapLabelDensity} onChange={(value) => updateSetting("heatmapLabelDensity", value as VisualizationSettings["heatmapLabelDensity"])}><option value="auto">Auto (legible)</option><option value="all">All labels</option><option value="none">Hidden</option></SelectControl>
+                {settings.heatmapDisplay === "rectangular" ? <ToggleControl label="Cell values when legible" checked={settings.heatmapShowValues} onChange={(value) => updateSetting("heatmapShowValues", value)} /> : null}
+                {settings.heatmapDisplay === "rectangular" ? <><ToggleControl label="Coordinated raw-value row summary" checked={settings.heatmapShowSidePlot} onChange={(value) => updateSetting("heatmapShowSidePlot", value)} />
+                {settings.heatmapShowSidePlot ? <><SelectControl label="Raw row summary" value={settings.heatmapSidePlotStatistic} onChange={(value) => updateSetting("heatmapSidePlotStatistic", value as VisualizationSettings["heatmapSidePlotStatistic"])}><option value="mean">Mean</option><option value="sd">SD</option><option value="range">Range</option></SelectControl><p className="text-[11px] leading-4 text-muted">The side plot summarizes uploaded values before heatmap scaling; correlation heatmaps summarize displayed coefficients.</p></> : null}</> : <p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Circular view keeps cluster ordering, cut tracks, and annotations. Cell text, dendrogram geometry, and the coordinated side plot are available in rectangular view.</p>}
+              </ControlGroup>
+              {plotType !== "heatmap" ? <ControlGroup title="Clustering">
+                {plotType === "correlation-heatmap" ? <ToggleControl label="Cluster variables (linked rows + columns)" checked={settings.clusterRows && settings.clusterColumns} onChange={(value) => setSettings((current) => ({ ...current, clusterRows: value, clusterColumns: value }))} /> : <><ToggleControl label="Cluster rows" checked={settings.clusterRows} onChange={(value) => updateSetting("clusterRows", value)} /><ToggleControl label="Cluster columns" checked={settings.clusterColumns} onChange={(value) => updateSetting("clusterColumns", value)} /></>}
+                {(settings.clusterRows || settings.clusterColumns) ? <>
+                  <SelectControl label="Distance" value={settings.heatmapDistance} onChange={(value) => updateSetting("heatmapDistance", value as VisualizationSettings["heatmapDistance"])}><option value="euclidean">Euclidean</option><option value="correlation">1 − Pearson correlation</option></SelectControl>
+                  <SelectControl label="Linkage" value={settings.heatmapLinkage} onChange={(value) => updateSetting("heatmapLinkage", value as VisualizationSettings["heatmapLinkage"])}><option value="average">Average</option><option value="complete">Complete</option><option value="single">Single</option></SelectControl>
+                  {settings.heatmapDisplay === "rectangular" ? <ToggleControl label="Dendrograms" checked={settings.heatmapShowDendrograms} onChange={(value) => updateSetting("heatmapShowDendrograms", value)} /> : null}
+                  {plotType === "correlation-heatmap" ? <RangeControl label="Variable cluster cut" value={settings.heatmapRowClusters} minimum={1} maximum={8} step={1} onChange={(value) => setSettings((current) => ({ ...current, heatmapRowClusters: value, heatmapColumnClusters: value }))} /> : <>{settings.clusterRows ? <RangeControl label="Row cluster cut" value={settings.heatmapRowClusters} minimum={1} maximum={8} step={1} onChange={(value) => updateSetting("heatmapRowClusters", value)} /> : null}{settings.clusterColumns ? <RangeControl label="Column cluster cut" value={settings.heatmapColumnClusters} minimum={1} maximum={8} step={1} onChange={(value) => updateSetting("heatmapColumnClusters", value)} /> : null}</>}
+                  <p className="text-[11px] leading-4 text-muted">Ordering, distance, linkage, and cut count are deterministic and included in the exported configuration.{plotType === "correlation-heatmap" ? " Symmetric rows and columns always share one variable order." : ""}</p>
+                </> : null}
+              </ControlGroup> : null}
+              <ControlGroup title="Annotation tracks">
+                <TextareaControl label="Row annotations (TSV)" value={settings.heatmapRowAnnotationData} onChange={(value) => updateSetting("heatmapRowAnnotationData", value)} placeholder={"id\tpathway[categorical]\nTP53\tp53 response\nEGFR\tRTK"} hint="First column is a stable row ID; append [categorical] or [continuous] to declare each track." />
+                <TextareaControl label="Column annotations (TSV)" value={settings.heatmapColumnAnnotationData} onChange={(value) => updateSetting("heatmapColumnAnnotationData", value)} placeholder={"id\tgroup[categorical]\tbatch[categorical]\nControl_1\tControl\t1\nTreatment_1\tTreatment\t2"} hint="IDs are matched by name, never by row position. Undeclared numeric tracks trigger a warning instead of silently assuming coded categories." />
+              </ControlGroup>
+            </> : null}
             {plotType === "km" ? <ControlGroup title="Survival"><ToggleControl label="Show numbers at risk" checked={settings.showRiskTable} onChange={(value) => updateSetting("showRiskTable", value)} /><p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Kaplan–Meier estimates and censor marks are calculated from individual records. A log-rank P value is intentionally omitted until a tested inferential module is added.</p></ControlGroup> : null}
             {plotType === "survival-forest" ? <ControlGroup title="Forest reference"><RangeControl label="Null reference" value={settings.forestReferenceValue} minimum={0} maximum={5} step={0.1} onChange={(value) => updateSetting("forestReferenceValue", value)} /><p className="text-[11px] leading-4 text-muted">Use 1 for ratios such as HR/OR and 0 for additive coefficients.</p></ControlGroup> : null}
 
@@ -1061,8 +1107,8 @@ export function VisualizationStudio() {
 
               <ControlGroup title="Editable colors">
                 {categoryLabels.map((label, index) => <ColorControl key={`${label}-${index}`} label={`${index + 1} · ${label}`} value={settings.categoricalColors[index] ?? journalThemes[themeId].categorical[index % journalThemes[themeId].categorical.length]} onChange={(value) => updateCategoryColor(index, value)} />)}
-                {plotType === "enrichment" || plotType === "enrichment-bar" ? <><ColorControl label="Sequential low" value={settings.continuousLow} onChange={(value) => updateSetting("continuousLow", value)} /><ColorControl label="Sequential high" value={settings.continuousHigh} onChange={(value) => updateSetting("continuousHigh", value)} /></> : null}
-                {(["heatmap", "clustered-heatmap", "correlation-heatmap"] as PlotType[]).includes(plotType) ? <><ColorControl label="Diverging low" value={settings.divergingLow} onChange={(value) => updateSetting("divergingLow", value)} /><ColorControl label="Midpoint" value={settings.divergingMid} onChange={(value) => updateSetting("divergingMid", value)} /><ColorControl label="Diverging high" value={settings.divergingHigh} onChange={(value) => updateSetting("divergingHigh", value)} /></> : null}
+                {plotType === "enrichment" || plotType === "enrichment-bar" || ((plotType === "heatmap" || plotType === "clustered-heatmap") && settings.heatmapScale === "none" && settings.heatmapColorMode === "sequential") ? <><ColorControl label="Sequential low" value={settings.continuousLow} onChange={(value) => updateSetting("continuousLow", value)} /><ColorControl label="Sequential high" value={settings.continuousHigh} onChange={(value) => updateSetting("continuousHigh", value)} /></> : null}
+                {(["heatmap", "clustered-heatmap", "correlation-heatmap"] as PlotType[]).includes(plotType) && (plotType === "correlation-heatmap" || settings.heatmapScale !== "none" || settings.heatmapColorMode === "diverging") ? <><ColorControl label="Diverging low" value={settings.divergingLow} onChange={(value) => updateSetting("divergingLow", value)} /><ColorControl label="Midpoint" value={settings.divergingMid} onChange={(value) => updateSetting("divergingMid", value)} /><ColorControl label="Diverging high" value={settings.divergingHigh} onChange={(value) => updateSetting("divergingHigh", value)} /></> : null}
               </ControlGroup>
             </CardBody>
           </Card>

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ReactNode, Ref } from "react";
 import { cn } from "@/lib/cn";
 
 export function Card({
@@ -44,11 +44,13 @@ export function CardHeader({
 export function CardBody({
   children,
   className,
+  ref,
 }: {
   children: ReactNode;
   className?: string;
+  ref?: Ref<HTMLDivElement>;
 }) {
-  return <div className={cn("p-4", className)}>{children}</div>;
+  return <div ref={ref} className={cn("p-4", className)}>{children}</div>;
 }
 
 export function SectionPanel({

--- a/src/lib/plot-module-rendering.test.tsx
+++ b/src/lib/plot-module-rendering.test.tsx
@@ -14,7 +14,7 @@ import {
 
 const expectedAdvancedRenderers = new Set([
   "line", "scatter", "correlation", "pcoa", "umap", "box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "ma", "quadrant", "errorbar", "area", "lollipop",
-  "clustered-heatmap", "correlation-heatmap", "enrichment-bar", "gsea", "km", "survival-forest", "roc", "venn",
+  "heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment-bar", "gsea", "km", "survival-forest", "roc", "venn",
   "upset", "sankey", "chord", "circos",
   "pie", "donut", "rose", "waffle", "treemap", "sunburst", "radar", "polar-profile", "population-pyramid",
 ]);
@@ -107,6 +107,18 @@ describe("registered plot-module examples", () => {
     expect(summaryX).toBeLessThan(300);
     expect(markup).toContain("two-sided t p");
     expect(markup).not.toMatch(/(?:NaN|Infinity|-Infinity|undefined)/);
+  });
+
+  it("assigns distinct static colors to categorical annotation levels beyond the base palette", () => {
+    const heatmapModule = plotModuleRegistry.get("heatmap");
+    const dataset = parseDelimitedData(heatmapModule.examples[0].data);
+    const columnIds = dataset.headers.slice(1);
+    const annotation = ["id\tcohort[categorical]", ...columnIds.map((id, index) => `${id}\tLevel_${index + 1}`)].join("\n");
+    const settings = { ...defaultVisualizationSettings, width: 520, height: 420, heatmapColumnAnnotationData: annotation };
+    expect(validatePlotDataset(heatmapModule.definition, dataset, {}, settings).errors).toEqual([]);
+    const markup = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="heatmap" dataset={dataset} mapping={{}} settings={settings} themeId={defaultVisualizationThemeId} />);
+    const swatchFills = [...markup.matchAll(/data-no-clip="true"[^>]*fill="([^"]+)"/gi)].map((match) => match[1]);
+    expect(new Set(swatchFills).size).toBeGreaterThanOrEqual(Math.min(columnIds.length, 5));
   });
 
   it("calculates long-form bar summaries without requiring a precomputed error column", () => {
@@ -257,5 +269,51 @@ describe("registered plot-module examples", () => {
         }
       }
     }
+  });
+
+  it("renders aligned annotations, deterministic cuts, dendrograms, and a coordinated heatmap summary", () => {
+    const heatmapModule = plotModuleRegistry.get("clustered-heatmap");
+    const dataset = parseDelimitedData(heatmapModule.examples[0].data);
+    const settings = {
+      ...defaultVisualizationSettings,
+      width: 520,
+      height: 420,
+      heatmapRowAnnotationData: "id\tmodule\nTP53\tDamage\nCDKN1A\tDamage\nEGFR\tRTK",
+      heatmapColumnAnnotationData: "id\tgroup\tbatch\nControl_1\tControl\t1\nTreatment_1\tTreatment\t2",
+      heatmapShowSidePlot: true,
+      heatmapShowValues: true,
+    };
+    const validation = validatePlotDataset(heatmapModule.definition, dataset, {}, settings);
+    expect(validation.errors).toEqual([]);
+    expect(validation.warnings.join(" ")).toMatch(/missing from the annotation table/);
+    const markup = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="clustered-heatmap" dataset={dataset} mapping={{}} settings={settings} themeId={defaultVisualizationThemeId} />);
+    expect(markup).toContain('data-plot-family="rectangular-heatmap"');
+    expect(markup).toContain('data-annotation-target="row"');
+    expect(markup).toContain('data-annotation-target="column"');
+    expect(markup).toContain('data-cluster-cut="row"');
+    expect(markup).toContain('data-cluster-cut="column"');
+    expect(markup).toContain('data-plot-element="heatmap-side-plot"');
+    expect(markup).toContain('data-plot-element="heatmap-color-legend"');
+    expect(markup).toContain('data-plot-element="heatmap-annotation-legend"');
+    expect(markup).toContain("Rows");
+    expect(markup).toContain("Columns");
+    const rawSummaryValues = [...markup.matchAll(/<title>mean: ([^<]+)<\/title>/g)].map((match) => Number(match[1]));
+    expect(rawSummaryValues.some((value) => Math.abs(value) > 1)).toBe(true);
+    expect(markup).not.toMatch(/(?:NaN|Infinity|-Infinity|undefined)/);
+  });
+
+  it("renders triangular correlation and circular heatmap views with finite geometry", () => {
+    const correlationModule = plotModuleRegistry.get("correlation-heatmap");
+    const correlationDataset = parseDelimitedData(correlationModule.examples[0].data);
+    const triangular = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="correlation-heatmap" dataset={correlationDataset} mapping={{}} settings={{ ...defaultVisualizationSettings, width: 520, height: 420, heatmapTriangle: "lower" }} themeId={defaultVisualizationThemeId} />);
+    const variableCount = correlationDataset.headers.length - 1;
+    expect((triangular.match(/data-plot-element="heatmap-cell"/g) ?? [])).toHaveLength(variableCount * (variableCount + 1) / 2);
+
+    const heatmapModule = plotModuleRegistry.get("heatmap");
+    const heatmapDataset = parseDelimitedData(heatmapModule.examples[0].data);
+    const circular = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="heatmap" dataset={heatmapDataset} mapping={{}} settings={{ ...defaultVisualizationSettings, width: 420, height: 420, heatmapDisplay: "circular", heatmapScale: "none", heatmapColorMode: "sequential" }} themeId={defaultVisualizationThemeId} />);
+    expect(circular).toContain('data-plot-family="circular-heatmap"');
+    expect(circular).toContain('data-plot-element="heatmap-cell"');
+    expect(circular).not.toMatch(/(?:NaN|Infinity|-Infinity|undefined)/);
   });
 });

--- a/src/lib/visualization-advanced.test.ts
+++ b/src/lib/visualization-advanced.test.ts
@@ -4,7 +4,9 @@ import {
   correlation,
   correlationPValue,
   correlationMatrix,
+  cutHierarchicalCluster,
   hierarchicalClusterOrder,
+  hierarchicalClusterTree,
   kaplanMeier,
   rankValues,
   rocCurve,
@@ -38,6 +40,27 @@ describe("advanced visualization statistics", () => {
     expect([...order].sort((a, b) => a - b)).toEqual([0, 1, 2, 3]);
     expect(Math.abs(order.indexOf(0) - order.indexOf(1))).toBe(1);
     expect(Math.abs(order.indexOf(2) - order.indexOf(3))).toBe(1);
+  });
+
+  it("supports explicit distance/linkage choices and reproducible cluster cuts", () => {
+    const vectors = [[0, 0, 0], [0.1, 0.1, 0.1], [8, 8, 8], [8.2, 8.1, 8.3]];
+    for (const linkage of ["average", "complete", "single"] as const) {
+      const tree = hierarchicalClusterTree(vectors, "euclidean", linkage);
+      expect(tree?.order).toEqual(hierarchicalClusterOrder(vectors, "euclidean", linkage));
+      const cuts = cutHierarchicalCluster(tree, 2);
+      expect(cuts[0]).toBe(cuts[1]);
+      expect(cuts[2]).toBe(cuts[3]);
+      expect(cuts[0]).not.toBe(cuts[2]);
+    }
+    expect(() => hierarchicalClusterTree(vectors, "correlation", "average")).toThrow(/zero-variance/);
+  });
+
+  it("clusters the maximum supported 250 × 100 matrix without repeated vector-distance expansion", () => {
+    const vectors = Array.from({ length: 250 }, (_, row) => Array.from({ length: 100 }, (_, column) => Math.sin(row * 0.17 + column * 0.11) + row * 0.002));
+    const started = performance.now();
+    const tree = hierarchicalClusterTree(vectors, "euclidean", "average");
+    expect(tree?.order).toHaveLength(250);
+    expect(performance.now() - started).toBeLessThan(3_000);
   });
 
   it("computes Kaplan-Meier survival after tied events and censoring", () => {

--- a/src/lib/visualization-advanced.ts
+++ b/src/lib/visualization-advanced.ts
@@ -106,23 +106,48 @@ function euclidean(left: number[], right: number[]) {
   return Math.sqrt(left.reduce((sum, value, index) => sum + (value - right[index]) ** 2, 0));
 }
 
-export function hierarchicalClusterOrder(vectors: number[][]) {
-  if (vectors.length <= 1) return vectors.map((_, index) => index);
-  type Cluster = { members: number[]; order: number[] };
-  const clusters: Cluster[] = vectors.map((_, index) => ({ members: [index], order: [index] }));
-  const averageDistance = (left: Cluster, right: Cluster) => {
-    const distances = left.members.flatMap((a) => right.members.map((b) => euclidean(vectors[a], vectors[b])));
-    return mean(distances);
-  };
+export type ClusterDistance = "euclidean" | "correlation";
+export type ClusterLinkage = "average" | "complete" | "single";
+export type HierarchicalClusterNode = {
+  id: string;
+  members: number[];
+  order: number[];
+  height: number;
+  left?: HierarchicalClusterNode;
+  right?: HierarchicalClusterNode;
+};
+
+function vectorDistance(left: number[], right: number[], distance: ClusterDistance) {
+  if (distance === "correlation") {
+    const coefficient = pearsonCorrelation(left, right);
+    if (!Number.isFinite(coefficient)) throw new Error("Correlation distance is undefined for a zero-variance vector.");
+    return Math.max(0, 1 - coefficient);
+  }
+  return euclidean(left, right);
+}
+
+export function hierarchicalClusterTree(
+  vectors: number[][],
+  distance: ClusterDistance = "euclidean",
+  linkage: ClusterLinkage = "average",
+): HierarchicalClusterNode | null {
+  if (vectors.length === 0) return null;
+  const clusters: HierarchicalClusterNode[] = vectors.map((_, index) => ({ id: `leaf-${index}`, members: [index], order: [index], height: 0 }));
+  const distances = new Map<string, number>();
+  const distanceKey = (left: HierarchicalClusterNode, right: HierarchicalClusterNode) => left.id < right.id ? `${left.id}\u0000${right.id}` : `${right.id}\u0000${left.id}`;
+  const getDistance = (left: HierarchicalClusterNode, right: HierarchicalClusterNode) => distances.get(distanceKey(left, right)) ?? Number.POSITIVE_INFINITY;
+  for (let left = 0; left < clusters.length; left += 1) {
+    for (let right = left + 1; right < clusters.length; right += 1) distances.set(distanceKey(clusters[left], clusters[right]), vectorDistance(vectors[left], vectors[right], distance));
+  }
   while (clusters.length > 1) {
     let bestI = 0;
     let bestJ = 1;
     let bestDistance = Number.POSITIVE_INFINITY;
     for (let i = 0; i < clusters.length; i += 1) {
       for (let j = i + 1; j < clusters.length; j += 1) {
-        const distance = averageDistance(clusters[i], clusters[j]);
-        if (distance < bestDistance - 1e-12) {
-          bestDistance = distance;
+        const candidateDistance = getDistance(clusters[i], clusters[j]);
+        if (candidateDistance < bestDistance - 1e-12) {
+          bestDistance = candidateDistance;
           bestI = i;
           bestJ = j;
         }
@@ -130,11 +155,60 @@ export function hierarchicalClusterOrder(vectors: number[][]) {
     }
     const left = clusters[bestI];
     const right = clusters[bestJ];
-    const merged: Cluster = { members: [...left.members, ...right.members], order: [...left.order, ...right.order] };
+    const merged: HierarchicalClusterNode = {
+      id: `node-${left.id}-${right.id}`,
+      members: [...left.members, ...right.members],
+      order: [...left.order, ...right.order],
+      height: bestDistance,
+      left,
+      right,
+    };
+    const updatedDistances = clusters.flatMap((other) => {
+      if (other === left || other === right) return;
+      const leftDistance = getDistance(left, other);
+      const rightDistance = getDistance(right, other);
+      const mergedDistance = linkage === "single"
+        ? Math.min(leftDistance, rightDistance)
+        : linkage === "complete"
+          ? Math.max(leftDistance, rightDistance)
+          : (left.members.length * leftDistance + right.members.length * rightDistance) / (left.members.length + right.members.length);
+      return [{ other, mergedDistance }];
+    }).filter((entry): entry is { other: HierarchicalClusterNode; mergedDistance: number } => Boolean(entry));
+    [...distances.keys()].forEach((key) => {
+      const [firstId, secondId] = key.split("\u0000");
+      if (firstId === left.id || secondId === left.id || firstId === right.id || secondId === right.id) distances.delete(key);
+    });
+    updatedDistances.forEach(({ other, mergedDistance }) => distances.set(distanceKey(merged, other), mergedDistance));
     clusters.splice(bestJ, 1);
     clusters.splice(bestI, 1, merged);
   }
-  return clusters[0].order;
+  return clusters[0];
+}
+
+export function hierarchicalClusterOrder(
+  vectors: number[][],
+  distance: ClusterDistance = "euclidean",
+  linkage: ClusterLinkage = "average",
+) {
+  return hierarchicalClusterTree(vectors, distance, linkage)?.order ?? [];
+}
+
+export function cutHierarchicalCluster(tree: HierarchicalClusterNode | null, clusterCount: number) {
+  if (!tree) return [];
+  const requested = Math.max(1, Math.min(Math.floor(clusterCount), tree.members.length));
+  const clusters = [tree];
+  while (clusters.length < requested) {
+    const splittable = clusters
+      .map((node, index) => ({ node, index }))
+      .filter(({ node }) => node.left && node.right)
+      .sort((a, b) => b.node.height - a.node.height || Math.min(...a.node.members) - Math.min(...b.node.members))[0];
+    if (!splittable?.node.left || !splittable.node.right) break;
+    clusters.splice(splittable.index, 1, splittable.node.left, splittable.node.right);
+  }
+  clusters.sort((left, right) => Math.min(...left.members) - Math.min(...right.members));
+  const labels = Array(tree.members.length).fill(0) as number[];
+  clusters.forEach((node, clusterIndex) => node.members.forEach((member) => { labels[member] = clusterIndex; }));
+  return labels;
 }
 
 export type KaplanMeierPoint = { time: number; survival: number; atRisk: number; events: number; censored: number };

--- a/src/lib/visualization-studio.test.ts
+++ b/src/lib/visualization-studio.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  alignHeatmapAnnotations,
+  categoricalColorForIndex,
   boxStatistics,
   confidenceInterval95,
   covarianceEllipsePoints,
@@ -230,6 +232,106 @@ describe("Visualization Studio data contracts", () => {
 
     const constantCorrelation = validatePlotDataset(getPlotDefinition("correlation-heatmap"), parseDelimitedData("sample\tA\tB\nS1\t1\t2\nS2\t1\t3\nS3\t1\t4"), {});
     expect(constantCorrelation.errors).toContain("Correlation is undefined for constant columns: A.");
+  });
+
+  it("aligns heatmap annotations by stable IDs and reports every mismatch class", () => {
+    const aligned = alignHeatmapAnnotations("id\tgroup\tage\nS2\tB\t42\nS1\tA\t37\nS4\tC\t55", ["S1", "S2", "S3"], "column");
+    expect(aligned.matchedIds).toBe(2);
+    expect(aligned.tracks.map((track) => [track.name, track.kind])).toEqual([["group", "categorical"], ["age", "continuous"]]);
+    expect(aligned.tracks[0].values.get("S1")).toBe("A");
+    expect(aligned.missingIds).toEqual(["S3"]);
+    expect(aligned.extraIds).toEqual(["S4"]);
+    expect(aligned.warnings.join(" ")).toMatch(/missing.*S3/i);
+    expect(aligned.warnings.join(" ")).toMatch(/ignored.*S4/i);
+    expect(aligned.warnings.join(" ")).toMatch(/inferred as continuous/i);
+
+    const coded = alignHeatmapAnnotations("id\tbatch[categorical]\tage[continuous]\nS1\t1\t37\nS2\t2\t42", ["S1", "S2"], "column");
+    expect(coded.tracks.map((track) => [track.name, track.kind])).toEqual([["batch", "categorical"], ["age", "continuous"]]);
+    expect(coded.warnings.join(" ")).not.toMatch(/batch.*inferred/i);
+    expect(alignHeatmapAnnotations("id\tage[continuous]\nS1\told", ["S1"], "row").errors.join(" ")).toMatch(/declared continuous.*non-numeric/);
+
+    const duplicate = alignHeatmapAnnotations("id\tgroup\nS1\tA\nS1\tB", ["S1"], "row");
+    expect(duplicate.errors.join(" ")).toMatch(/unique.*S1/i);
+
+    const duplicateDeclaredNames = alignHeatmapAnnotations("id\tbatch\tbatch[categorical]\nS1\tA\t1", ["S1"], "row");
+    expect(duplicateDeclaredNames.errors.join(" ")).toMatch(/track names.*unique.*batch/i);
+  });
+
+  it("applies tighter browser safety limits to circular heatmaps and surfaces annotation mismatches", () => {
+    const rows = Array.from({ length: 81 }, (_, index) => `G${index}\t${index}\t${index + 1}`).join("\n");
+    const settings = { ...defaultVisualizationSettings, heatmapDisplay: "circular" as const, heatmapRowAnnotationData: "id\tmodule\nG0\tA\nEXTRA\tB" };
+    const result = validatePlotDataset(getPlotDefinition("clustered-heatmap"), parseDelimitedData(`gene\tS1\tS2\n${rows}`), {}, settings);
+    expect(result.errors.join(" ")).toMatch(/limited to 80 rows/);
+    expect(result.warnings.join(" ")).toMatch(/80 row IDs are missing/);
+    expect(result.warnings.join(" ")).toMatch(/EXTRA/);
+  });
+
+  it("uses rendered heatmap geometry to block cramped rectangular and circular exports", () => {
+    const dataset = parseDelimitedData("gene\tS1\tS2\tS3\nG1\t1\t2\t3\nG2\t2\t4\t5\nG3\t3\t2\t7");
+    const crowdedRectangular = validatePlotDataset(getPlotDefinition("clustered-heatmap"), dataset, {}, {
+      ...defaultVisualizationSettings,
+      width: 340,
+      height: 340,
+      heatmapShowSidePlot: true,
+      heatmapRowAnnotationData: "id\ta\tb\tc\nG1\tA\tB\tC\nG2\tB\tC\tA\nG3\tC\tA\tB",
+      heatmapColumnAnnotationData: "id\tgroup\tbatch\tphase\nS1\tA\t1\tX\nS2\tB\t2\tY\nS3\tC\t3\tZ",
+    });
+    expect(crowdedRectangular.errors.join(" ")).toMatch(/usable width.*minimum 70 px/i);
+
+    const circularRows = Array.from({ length: 28 }, (_, index) => `G${index}\t${index + 1}\t${index + 2}\t${index + 3}`).join("\n");
+    const crampedCircular = validatePlotDataset(getPlotDefinition("clustered-heatmap"), parseDelimitedData(`gene\tS1\tS2\tS3\n${circularRows}`), {}, {
+      ...defaultVisualizationSettings,
+      width: 340,
+      height: 340,
+      heatmapDisplay: "circular",
+      heatmapColumnAnnotationData: "id\ta\tb\tc\td\te\tf\nS1\tA\tB\tC\tD\tE\tF\nS2\tB\tC\tD\tE\tF\tG\nS3\tC\tD\tE\tF\tG\tH",
+    });
+    expect(crampedCircular.errors.join(" ")).toMatch(/rings would be|tracks do not fit/i);
+
+    const twentyRows = Array.from({ length: 20 }, (_, index) => `G${index}\t${index + 1}\t${index + 2}\t${index + 3}`).join("\n");
+    const allLargeRingLabels = validatePlotDataset(getPlotDefinition("clustered-heatmap"), parseDelimitedData(`gene\tA\tB\tC\n${twentyRows}`), {}, {
+      ...defaultVisualizationSettings,
+      width: 340,
+      height: 340,
+      legendSize: 16,
+      heatmapDisplay: "circular",
+      heatmapLabelDensity: "all",
+    });
+    expect(allLargeRingLabels.errors.join(" ")).toMatch(/ring identities.*Auto label density/i);
+
+    const eightColumns = Array.from({ length: 8 }, (_, index) => `S${index + 1}`);
+    const eightRows = Array.from({ length: 8 }, (_, rowIndex) => `G${rowIndex + 1}\t${eightColumns.map((_, columnIndex) => rowIndex * 8 + columnIndex + 1).join("\t")}`).join("\n");
+    const wideCutLegend = validatePlotDataset(getPlotDefinition("clustered-heatmap"), parseDelimitedData(`gene\t${eightColumns.join("\t")}\n${eightRows}`), {}, {
+      ...defaultVisualizationSettings,
+      width: 300,
+      height: 340,
+      legendSize: 16,
+      heatmapRowClusters: 8,
+      heatmapColumnClusters: 8,
+    });
+    expect(wideCutLegend.errors.join(" ")).toMatch(/cluster-cut legend needs/i);
+  });
+
+  it("keeps synthesized annotation colors unique through the heatmap category ceiling", () => {
+    const colors = Array.from({ length: 250 }, (_, index) => categoricalColorForIndex(index, defaultVisualizationSettings.categoricalColors));
+    expect(new Set(colors).size).toBe(250);
+  });
+
+  it("rejects stale correlation configurations with one-sided clustering", () => {
+    const dataset = parseDelimitedData("sample\tA\tB\tC\nS1\t1\t3\t2\nS2\t2\t2\t4\nS3\t4\t1\t5\nS4\t5\t4\t7");
+    const result = validatePlotDataset(getPlotDefinition("correlation-heatmap"), dataset, {}, {
+      ...defaultVisualizationSettings,
+      clusterRows: true,
+      clusterColumns: false,
+    });
+    expect(result.errors.join(" ")).toMatch(/enabled or disabled together/i);
+  });
+
+  it("rejects undefined correlation distances instead of treating zero variance as zero correlation", () => {
+    const dataset = parseDelimitedData("gene\tS1\tS2\tS3\nConstant\t4\t4\t4\nVariable\t1\t2\t4\nOther\t2\t5\t7");
+    const settings = { ...defaultVisualizationSettings, heatmapDistance: "correlation" as const, clusterRows: true, clusterColumns: false };
+    const result = validatePlotDataset(getPlotDefinition("clustered-heatmap"), dataset, {}, settings);
+    expect(result.errors.join(" ")).toMatch(/zero-variance row vectors: Constant/);
   });
 
   it("requires a mapped non-negative error column when bar SD or SEM is enabled", () => {

--- a/src/lib/visualization-studio.ts
+++ b/src/lib/visualization-studio.ts
@@ -241,7 +241,21 @@ export type VisualizationSettings = {
   foldChangeThreshold: number;
   pValueThreshold: number;
   labelLimit: number;
-  heatmapScale: "row" | "none";
+  heatmapScale: "row" | "column" | "none";
+  heatmapColorMode: "diverging" | "sequential";
+  heatmapDisplay: "rectangular" | "circular";
+  heatmapTriangle: "full" | "lower" | "upper";
+  heatmapDistance: "euclidean" | "correlation";
+  heatmapLinkage: "average" | "complete" | "single";
+  heatmapShowDendrograms: boolean;
+  heatmapRowClusters: number;
+  heatmapColumnClusters: number;
+  heatmapShowValues: boolean;
+  heatmapShowSidePlot: boolean;
+  heatmapSidePlotStatistic: "mean" | "sd" | "range";
+  heatmapLabelDensity: "auto" | "all" | "none";
+  heatmapRowAnnotationData: string;
+  heatmapColumnAnnotationData: string;
   correlationMethod: "pearson" | "spearman";
   xThreshold: number;
   yThreshold: number;
@@ -332,6 +346,20 @@ export const defaultVisualizationSettings: VisualizationSettings = {
   pValueThreshold: 0.05,
   labelLimit: 8,
   heatmapScale: "row",
+  heatmapColorMode: "diverging",
+  heatmapDisplay: "rectangular",
+  heatmapTriangle: "lower",
+  heatmapDistance: "euclidean",
+  heatmapLinkage: "average",
+  heatmapShowDendrograms: true,
+  heatmapRowClusters: 3,
+  heatmapColumnClusters: 3,
+  heatmapShowValues: false,
+  heatmapShowSidePlot: false,
+  heatmapSidePlotStatistic: "mean",
+  heatmapLabelDensity: "auto",
+  heatmapRowAnnotationData: "",
+  heatmapColumnAnnotationData: "",
   correlationMethod: "pearson",
   xThreshold: 0,
   yThreshold: 0,
@@ -1245,7 +1273,7 @@ const plotDefinitionSeeds: PlotDefinition[] = [
     id,
     name: id === "clustered-heatmap" ? "Clustered heatmap" : "Correlation heatmap",
     family: "Matrix",
-    summary: id === "clustered-heatmap" ? "Expression heatmap with deterministic average-linkage row and column ordering." : "Pearson or Spearman correlation calculated across numeric columns and displayed as a symmetric matrix.",
+    summary: id === "clustered-heatmap" ? "Matrix heatmap with explicit, deterministic row and column clustering." : "Pearson or Spearman correlation calculated across numeric columns and displayed as a symmetric matrix.",
     inputHint: "First column supplies row labels; every remaining column must be numeric.",
     roles: [],
     defaultMapping: {},
@@ -1483,6 +1511,7 @@ export const plotReferences = {
   lollipop: { citation: "Jay & Brouwer, 2016. Lollipops in the Clinic: Information Dense Mutation Plots for Precision Medicine. PLoS ONE.", href: "https://doi.org/10.1371/journal.pone.0160519" },
   heatmap: { citation: "Wilkinson & Friendly, 2009. The History of the Cluster Heat Map. The American Statistician.", href: "https://doi.org/10.1198/tas.2009.0033" },
   clusteredHeatmap: { citation: "Eisen et al., 1998. Cluster analysis and display of genome-wide expression patterns. PNAS.", href: "https://doi.org/10.1073/pnas.95.25.14863" },
+  complexHeatmap: { citation: "Gu, Eils & Schlesner, 2016. Complex heatmaps reveal patterns and correlations in multidimensional genomic data. Bioinformatics.", href: "https://doi.org/10.1093/bioinformatics/btw313" },
   corrgram: { citation: "Friendly, 2002. Corrgrams: Exploratory Displays for Correlation Matrices. The American Statistician.", href: "https://doi.org/10.1198/000313002533" },
   enrichment: { citation: "Yu et al., 2012. clusterProfiler: an R package for comparing biological themes among gene clusters. OMICS.", href: "https://doi.org/10.1089/omi.2011.0118" },
   gsea: { citation: "Subramanian et al., 2005. Gene set enrichment analysis: a knowledge-based approach. PNAS.", href: "https://doi.org/10.1073/pnas.0506580102" },
@@ -1645,21 +1674,21 @@ const plotGuidanceSeeds: Record<PlotType, PlotGuidance> = {
     suitableData: "行列结构明确的数值矩阵，可使用原始尺度或经过合理标准化的值。",
     answers: "二维矩阵中哪些区域呈现高低模式、梯度、块状结构或异常值。",
     origin: "矩阵着色可追溯到 19 世纪统计图形；Wilkinson 与 Friendly 的历史综述梳理了它发展为现代热图的过程。",
-    references: [plotReferences.heatmap],
+    references: [plotReferences.heatmap, plotReferences.complexHeatmap],
   },
   "clustered-heatmap": {
     definition: "先按指定距离和连接方法对行列进行层次聚类，再按树状图顺序重排热图；颜色和树结构表达的是两层信息。",
     suitableData: "可比较的数值矩阵；行列聚类前应明确缩放、距离和连接方法。",
     answers: "哪些行或列具有相似模式，是否形成候选亚群、模块或共变结构。",
     origin: "聚类热图有更早的统计学前身；Eisen 等人在 1998 年把它用于全基因组表达模式后，使其成为组学分析的经典图形。",
-    references: [plotReferences.clusteredHeatmap, plotReferences.heatmap],
+    references: [plotReferences.clusteredHeatmap, plotReferences.heatmap, plotReferences.complexHeatmap],
   },
   "correlation-heatmap": {
     definition: "以同一组变量同时作为行和列，用颜色编码每对变量的相关系数，因此矩阵通常对称且对角线为 1。",
     suitableData: "同一批观察上测量的多个连续或有序变量。",
     answers: "变量之间的相关方向、强度、冗余和潜在模块结构是什么。",
     origin: "Friendly 在 2002 年提出 corrgram 体系，强调同时用颜色、顺序和符号阅读相关矩阵结构。",
-    references: [plotReferences.corrgram],
+    references: [plotReferences.corrgram, plotReferences.complexHeatmap],
   },
   enrichment: {
     definition: "每个功能条目用一个点表示，通常以位置编码富集比例、点大小编码命中数、颜色编码校正 P 值。",
@@ -1801,7 +1830,7 @@ const plotGuidanceSeeds: Record<PlotType, PlotGuidance> = {
 
 const advancedRendererIds = new Set<PlotType>([
   "line", "scatter", "correlation", "pcoa", "umap", "box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "ma", "quadrant", "errorbar", "area", "lollipop",
-  "clustered-heatmap", "correlation-heatmap", "enrichment-bar", "gsea", "km", "survival-forest", "roc", "venn",
+  "heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment-bar", "gsea", "km", "survival-forest", "roc", "venn",
   "upset", "sankey", "chord", "circos",
   "pie", "donut", "rose", "waffle", "treemap", "sunburst", "radar", "polar-profile", "population-pyramid",
 ]);
@@ -1827,9 +1856,9 @@ const specializedSettingKeys: Partial<Record<PlotType, Array<keyof Visualization
   volcano: ["showLabels", "foldChangeThreshold", "pValueThreshold", "labelLimit"],
   ma: ["showLabels", "foldChangeThreshold", "pValueThreshold", "labelLimit"], quadrant: ["showLabels", "xThreshold", "yThreshold"],
   errorbar: ["errorBarLineWidth", "errorBarCapSize"],
-  heatmap: ["heatmapScale", "divergingLow", "divergingMid", "divergingHigh"],
-  "clustered-heatmap": ["heatmapScale", "clusterRows", "clusterColumns", "divergingLow", "divergingMid", "divergingHigh"],
-  "correlation-heatmap": ["correlationMethod", "clusterRows", "clusterColumns", "divergingLow", "divergingMid", "divergingHigh"],
+  heatmap: ["heatmapScale", "heatmapColorMode", "heatmapDisplay", "heatmapShowValues", "heatmapShowSidePlot", "heatmapSidePlotStatistic", "heatmapLabelDensity", "heatmapRowAnnotationData", "heatmapColumnAnnotationData", "continuousLow", "continuousHigh", "divergingLow", "divergingMid", "divergingHigh"],
+  "clustered-heatmap": ["heatmapScale", "heatmapColorMode", "heatmapDisplay", "clusterRows", "clusterColumns", "heatmapDistance", "heatmapLinkage", "heatmapShowDendrograms", "heatmapRowClusters", "heatmapColumnClusters", "heatmapShowValues", "heatmapShowSidePlot", "heatmapSidePlotStatistic", "heatmapLabelDensity", "heatmapRowAnnotationData", "heatmapColumnAnnotationData", "continuousLow", "continuousHigh", "divergingLow", "divergingMid", "divergingHigh"],
+  "correlation-heatmap": ["correlationMethod", "heatmapDisplay", "heatmapTriangle", "clusterRows", "clusterColumns", "heatmapDistance", "heatmapLinkage", "heatmapShowDendrograms", "heatmapRowClusters", "heatmapColumnClusters", "heatmapShowValues", "heatmapShowSidePlot", "heatmapSidePlotStatistic", "heatmapLabelDensity", "heatmapRowAnnotationData", "heatmapColumnAnnotationData", "divergingLow", "divergingMid", "divergingHigh"],
   enrichment: ["continuousLow", "continuousHigh"], "enrichment-bar": ["continuousLow", "continuousHigh"],
   km: ["showRiskTable"], "survival-forest": ["forestReferenceValue"],
   pie: ["compositionLabelMode"], donut: ["compositionLabelMode", "donutHole"], waffle: ["compositionLabelMode", "waffleCells"],
@@ -2007,6 +2036,153 @@ export function parseNumericValue(value: string | undefined) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+export type HeatmapAnnotationTrack = {
+  name: string;
+  kind: "continuous" | "categorical";
+  values: Map<string, string>;
+  numericExtent: [number, number] | null;
+  categories: string[];
+};
+
+export type HeatmapAnnotationAlignment = {
+  tracks: HeatmapAnnotationTrack[];
+  errors: string[];
+  warnings: string[];
+  matchedIds: number;
+  missingIds: string[];
+  extraIds: string[];
+};
+
+export type HeatmapLayoutOptions = {
+  hasAnnotationLegend: boolean;
+  rowAnnotationTracks: number;
+  columnAnnotationTracks: number;
+  showRowCut: boolean;
+  showColumnCut: boolean;
+  showRowDendrogram: boolean;
+  showColumnDendrogram: boolean;
+  showSidePlot: boolean;
+  rowCount: number;
+  columnCount: number;
+  maxColumnLabelCharacters: number;
+  maxCutClusters: number;
+};
+
+/**
+ * One source of truth for compact heatmap geometry. Validation and rendering
+ * deliberately share these exact measurements so a view that passes the
+ * safety gate cannot later grow beyond its export frame.
+ */
+export function heatmapLayoutMetrics(settings: VisualizationSettings, options: HeatmapLayoutOptions) {
+  const annotationLegendWidth = options.hasAnnotationLegend ? Math.max(104, Math.ceil(Math.max(8, settings.legendSize) * 8)) : 0;
+  const left = Math.min(108, settings.width * 0.27);
+  const top = settings.title ? 48 : 24;
+  const bottom = 58;
+  const right = 22 + annotationLegendWidth;
+  const plotWidth = Math.max(0, settings.width - left - right);
+  const plotHeight = Math.max(0, settings.height - top - bottom);
+  const rowTrackCount = options.rowAnnotationTracks + (options.showRowCut ? 1 : 0);
+  const columnTrackCount = options.columnAnnotationTracks + (options.showColumnCut ? 1 : 0);
+  const rowTrackWidth = rowTrackCount * 6;
+  const columnTrackHeight = columnTrackCount * 6;
+  const rowDendrogramWidth = options.showRowDendrogram ? 28 : 0;
+  const columnDendrogramHeight = options.showColumnDendrogram ? 28 : 0;
+  const sidePlotWidth = options.showSidePlot ? 48 : 0;
+  const legendFontSize = Math.max(8, settings.legendSize);
+  const cutItemStep = Math.max(13, legendFontSize * 1.15);
+  const cutLegendWidth = options.maxCutClusters > 1 ? 12 + options.maxCutClusters * cutItemStep + legendFontSize * 0.7 : 0;
+  const colorLegendHeight = options.showRowCut || options.showColumnCut ? Math.max(36, legendFontSize * 3 + 10) : Math.max(18, legendFontSize + 8);
+  const matrixWidth = plotWidth - rowDendrogramWidth - rowTrackWidth - sidePlotWidth;
+  const matrixHeight = plotHeight - colorLegendHeight - columnDendrogramHeight - columnTrackHeight;
+  const labelReserve = settings.heatmapLabelDensity === "none"
+    ? 4
+    : Math.ceil(12 + Math.min(12, options.maxColumnLabelCharacters) * Math.max(8, settings.tickSize) * 0.58);
+  const circularOuterRadius = Math.min(plotWidth, plotHeight) / 2 - labelReserve - options.columnAnnotationTracks * 5;
+  const circularInnerRadius = Math.max(12, circularOuterRadius * 0.2);
+  const circularRingWidth = (circularOuterRadius - circularInnerRadius) / Math.max(1, options.rowCount);
+  const circularSectorArc = Math.PI * 2 * Math.max(0, circularOuterRadius) / Math.max(1, options.columnCount);
+  const circularRingListAvailableHeight = Math.max(0, plotHeight - (legendFontSize * 2 + 4) - colorLegendHeight);
+  return {
+    frame: { width: settings.width, height: settings.height, left, right, top, bottom, plotWidth, plotHeight },
+    annotationLegendWidth,
+    rowTrackCount,
+    columnTrackCount,
+    rowTrackWidth,
+    columnTrackHeight,
+    rowDendrogramWidth,
+    columnDendrogramHeight,
+    sidePlotWidth,
+    colorLegendHeight,
+    matrixWidth,
+    matrixHeight,
+    circularOuterRadius,
+    circularInnerRadius,
+    circularRingWidth,
+    circularSectorArc,
+    circularRingListAvailableHeight,
+    cutLegendWidth,
+  };
+}
+
+/** Expand a chosen categorical palette without silently reusing a color. */
+export function categoricalColorForIndex(index: number, colors: string[]) {
+  const safeColors = colors.length > 0 ? colors : ["#A7A5A0"];
+  const base = safeColors[index % safeColors.length];
+  const tier = Math.floor(index / safeColors.length);
+  if (tier === 0) return base;
+  // Golden-angle hues remain deterministic and unique across the browser
+  // safety ceiling (250 categories) while keeping restrained saturation.
+  const hue = ((index * 137.50776405003785) % 360).toFixed(6);
+  const saturation = 34 + (tier % 4) * 4;
+  const lightness = 42 + (tier % 5) * 5;
+  return `hsl(${hue} ${saturation}% ${lightness}%)`;
+}
+
+/** Parse and align a row/column annotation table by its stable first-column identifier. */
+export function alignHeatmapAnnotations(text: string, targetIds: string[], targetLabel: "row" | "column"): HeatmapAnnotationAlignment {
+  if (!text.trim()) return { tracks: [], errors: [], warnings: [], matchedIds: 0, missingIds: [], extraIds: [] };
+  const parsed = parseDelimitedData(text);
+  const errors = [...parsed.errors];
+  const warnings = [...parsed.warnings];
+  if (parsed.headers.length < 2) errors.push(`${targetLabel === "row" ? "Row" : "Column"} annotations need an ID column and at least one track.`);
+  if (parsed.headers.length > 7) errors.push(`${targetLabel === "row" ? "Row" : "Column"} annotations are limited to six tracks in the browser preview.`);
+  const idColumn = parsed.headers[0] ?? "id";
+  const ids = parsed.rows.map((row) => row[idColumn]?.trim()).filter(Boolean);
+  const duplicateIds = [...new Set(ids.filter((id, index) => ids.indexOf(id) !== index))];
+  if (duplicateIds.length > 0) errors.push(`${targetLabel === "row" ? "Row" : "Column"} annotation IDs must be unique; duplicates: ${duplicateIds.slice(0, 6).join(", ")}.`);
+  const idSet = new Set(ids);
+  const targetSet = new Set(targetIds);
+  const missingIds = targetIds.filter((id) => !idSet.has(id));
+  const extraIds = ids.filter((id) => !targetSet.has(id));
+  if (missingIds.length > 0) warnings.push(`${missingIds.length} ${targetLabel} ID${missingIds.length === 1 ? " is" : "s are"} missing from the annotation table: ${missingIds.slice(0, 5).join(", ")}${missingIds.length > 5 ? "…" : ""}.`);
+  if (extraIds.length > 0) warnings.push(`${extraIds.length} annotation ID${extraIds.length === 1 ? " does" : "s do"} not match the matrix and will be ignored: ${extraIds.slice(0, 5).join(", ")}${extraIds.length > 5 ? "…" : ""}.`);
+  const trackHeaders = parsed.headers.slice(1, 7);
+  const normalizedTrackNames = trackHeaders.map((header) => header.match(/^(.*?)\s*\[(categorical|continuous)\]\s*$/i)?.[1]?.trim() || header);
+  const duplicateTrackNames = [...new Set(normalizedTrackNames.filter((name, index) => normalizedTrackNames.indexOf(name) !== index))];
+  if (duplicateTrackNames.length > 0) errors.push(`${targetLabel === "row" ? "Row" : "Column"} annotation track names must remain unique after type declarations are removed; duplicates: ${duplicateTrackNames.join(", ")}.`);
+  const tracks = trackHeaders.map((header) => {
+    const declaration = header.match(/^(.*?)\s*\[(categorical|continuous)\]\s*$/i);
+    const name = declaration?.[1]?.trim() || header;
+    const declaredKind = declaration?.[2]?.toLowerCase() as "categorical" | "continuous" | undefined;
+    const values = new Map(parsed.rows.map((row) => [row[idColumn]?.trim(), row[header]?.trim() ?? ""]));
+    const matchedValues = targetIds.map((id) => values.get(id) ?? "").filter((value) => value !== "");
+    const numericValues = matchedValues.map((value) => parseNumericValue(value));
+    const allNumeric = matchedValues.length > 0 && numericValues.every((value) => value !== null);
+    if (declaredKind === "continuous" && !allNumeric) errors.push(`${targetLabel === "row" ? "Row" : "Column"} annotation track ${name} is declared continuous but contains non-numeric values.`);
+    const continuous = declaredKind === "continuous" || (declaredKind === undefined && allNumeric);
+    if (declaredKind === undefined && allNumeric) warnings.push(`Numeric annotation track ${name} was inferred as continuous; add [categorical] to the header for codes such as batch, stage, or cluster IDs.`);
+    const finite = numericValues.filter((value): value is number => value !== null);
+    return {
+      name,
+      kind: continuous ? "continuous" as const : "categorical" as const,
+      values,
+      numericExtent: continuous && finite.length > 0 ? [Math.min(...finite), Math.max(...finite)] as [number, number] : null,
+      categories: continuous ? [] : [...new Set(matchedValues)].sort((left, right) => left.localeCompare(right)),
+    };
+  });
+  return { tracks, errors, warnings, matchedIds: targetIds.filter((id) => idSet.has(id)).length, missingIds, extraIds };
+}
+
 export function parseRatioValue(value: string | undefined) {
   if (!value) return null;
   if (value.includes("/")) {
@@ -2076,6 +2252,39 @@ export function inferPlotMapping(definition: PlotDefinition, headers: string[]) 
   }));
 }
 
+function heatmapStandardize(values: number[]) {
+  const average = values.reduce((sum, value) => sum + value, 0) / Math.max(1, values.length);
+  const deviation = Math.sqrt(values.reduce((sum, value) => sum + (value - average) ** 2, 0) / Math.max(1, values.length - 1)) || 1;
+  return values.map((value) => (value - average) / deviation);
+}
+
+function heatmapRanks(values: number[]) {
+  const ordered = values.map((value, index) => ({ value, index })).sort((left, right) => left.value - right.value || left.index - right.index);
+  const ranks = Array(values.length).fill(0) as number[];
+  for (let start = 0; start < ordered.length;) {
+    let end = start;
+    while (end + 1 < ordered.length && ordered[end + 1].value === ordered[start].value) end += 1;
+    const rank = (start + end + 2) / 2;
+    for (let cursor = start; cursor <= end; cursor += 1) ranks[ordered[cursor].index] = rank;
+    start = end + 1;
+  }
+  return ranks;
+}
+
+function heatmapCorrelation(left: number[], right: number[], method: VisualizationSettings["correlationMethod"]) {
+  const x = method === "spearman" ? heatmapRanks(left) : left;
+  const y = method === "spearman" ? heatmapRanks(right) : right;
+  const xMean = x.reduce((sum, value) => sum + value, 0) / x.length;
+  const yMean = y.reduce((sum, value) => sum + value, 0) / y.length;
+  const numerator = x.reduce((sum, value, index) => sum + (value - xMean) * (y[index] - yMean), 0);
+  const denominator = Math.sqrt(x.reduce((sum, value) => sum + (value - xMean) ** 2, 0) * y.reduce((sum, value) => sum + (value - yMean) ** 2, 0));
+  return denominator > 0 ? numerator / denominator : Number.NaN;
+}
+
+function isZeroVariance(values: number[]) {
+  return values.length < 2 || values.every((value) => Math.abs(value - values[0]) <= 1e-12);
+}
+
 export function validatePlotDataset(
   definition: PlotDefinition,
   dataset: ParsedDataset,
@@ -2099,15 +2308,98 @@ export function validatePlotDataset(
 
   if (["heatmap", "clustered-heatmap", "correlation-heatmap"].includes(definition.id)) {
     if (dataset.headers.length < 3) errors.push("Heatmap data needs one row-label column and at least two numeric sample columns.");
+    const labelHeader = dataset.headers[0];
     const numericHeaders = dataset.headers.slice(1);
+    const rowIds = dataset.rows.map((row) => row[labelHeader]?.trim()).filter(Boolean);
+    if (rowIds.length !== dataset.rows.length) errors.push("Heatmap row identifiers must not be blank.");
+    if (new Set(rowIds).size !== rowIds.length) errors.push("Heatmap row identifiers must be unique so annotations and labels align reproducibly.");
     const invalid = dataset.rows.filter((row) => numericHeaders.some((header) => parseNumericValue(row[header]) === null));
     if (invalid.length > 0) errors.push(`${invalid.length} heatmap row${invalid.length === 1 ? "" : "s"} contain non-numeric or blank values.`);
     if (definition.id === "correlation-heatmap" && invalid.length === 0) {
       const constantHeaders = numericHeaders.filter((header) => new Set(dataset.rows.map((row) => parseNumericValue(row[header]))).size < 2);
       if (constantHeaders.length > 0) errors.push(`Correlation is undefined for constant columns: ${constantHeaders.join(", ")}.`);
     }
-    if (definition.id !== "correlation-heatmap" && dataset.rows.length > 250) errors.push("Heatmap previews are limited to 250 rows; select biologically justified features before plotting.");
-    if (numericHeaders.length > 100) errors.push("Heatmap previews are limited to 100 numeric columns to preserve legibility and browser performance.");
+    const circular = settings?.heatmapDisplay === "circular";
+    const rowLimit = circular ? 80 : 250;
+    const columnLimit = circular ? 60 : 100;
+    if (definition.id !== "correlation-heatmap" && dataset.rows.length > rowLimit) errors.push(`${circular ? "Circular h" : "H"}eatmap previews are limited to ${rowLimit} rows; select biologically justified features before plotting.`);
+    if (numericHeaders.length > columnLimit) errors.push(`${circular ? "Circular h" : "H"}eatmap previews are limited to ${columnLimit} numeric columns to preserve legibility and browser performance.`);
+    if (settings) {
+      if (invalid.length === 0 && settings.heatmapDistance === "correlation" && definition.id !== "heatmap") {
+        const rawMatrix = dataset.rows.map((row) => numericHeaders.map((header) => parseNumericValue(row[header]) ?? 0));
+        let clusteringMatrix = rawMatrix;
+        if (definition.id === "correlation-heatmap") {
+          const variables = numericHeaders.map((_, columnIndex) => rawMatrix.map((row) => row[columnIndex]));
+          clusteringMatrix = variables.map((left) => variables.map((right) => heatmapCorrelation(left, right, settings.correlationMethod)));
+        } else if (settings.heatmapScale === "row") clusteringMatrix = rawMatrix.map(heatmapStandardize);
+        else if (settings.heatmapScale === "column") {
+          const scaledColumns = numericHeaders.map((_, columnIndex) => heatmapStandardize(rawMatrix.map((row) => row[columnIndex])));
+          clusteringMatrix = rawMatrix.map((_, rowIndex) => scaledColumns.map((column) => column[rowIndex]));
+        }
+        const clusteringRowLabels = definition.id === "correlation-heatmap" ? numericHeaders : rowIds;
+        if (settings.clusterRows) {
+          const constantRows = clusteringMatrix.map((values, index) => isZeroVariance(values) || values.some((value) => !Number.isFinite(value)) ? clusteringRowLabels[index] : "").filter(Boolean);
+          if (constantRows.length > 0) errors.push(`Correlation distance is undefined for zero-variance row vectors: ${constantRows.slice(0, 8).join(", ")}${constantRows.length > 8 ? "…" : ""}. Use Euclidean distance or remove/transform these rows.`);
+        }
+        if (settings.clusterColumns) {
+          const constantColumns = numericHeaders.map((header, columnIndex) => ({ header, values: clusteringMatrix.map((row) => row[columnIndex]) })).filter(({ values }) => isZeroVariance(values) || values.some((value) => !Number.isFinite(value))).map(({ header }) => header);
+          if (constantColumns.length > 0) errors.push(`Correlation distance is undefined for zero-variance column vectors: ${constantColumns.slice(0, 8).join(", ")}${constantColumns.length > 8 ? "…" : ""}. Use Euclidean distance or remove/transform these columns.`);
+        }
+      }
+      const displayedRowIds = definition.id === "correlation-heatmap" ? numericHeaders : rowIds;
+      const rowAnnotations = alignHeatmapAnnotations(settings.heatmapRowAnnotationData, displayedRowIds, "row");
+      const columnAnnotations = alignHeatmapAnnotations(settings.heatmapColumnAnnotationData, numericHeaders, "column");
+      errors.push(...rowAnnotations.errors, ...columnAnnotations.errors);
+      warnings.push(...rowAnnotations.warnings, ...columnAnnotations.warnings);
+      const annotationTracks = [...rowAnnotations.tracks, ...columnAnnotations.tracks];
+      if (annotationTracks.length > 6) errors.push("The compact export supports at most six annotation tracks in total across rows and columns.");
+      const legendRows = annotationTracks.reduce((sum, track) => sum + 1 + (track.kind === "continuous" ? 2 : track.categories.length), 0) + (rowAnnotations.tracks.length > 0 ? 1 : 0) + (columnAnnotations.tracks.length > 0 ? 1 : 0);
+      const legendRowHeight = Math.max(8, settings.legendSize) + 3;
+      const maximumLegendRows = Math.max(4, Math.floor((settings.height - 54) / legendRowHeight));
+      if (legendRows > maximumLegendRows) errors.push(`Annotation legends need ${legendRows} compact rows but this ${settings.height}px-high export can display ${maximumLegendRows}; increase height or reduce tracks/categories.`);
+      if (settings.heatmapShowValues && settings.heatmapDisplay === "rectangular" && displayedRowIds.length * numericHeaders.length > 225) warnings.push("Cell values are shown only when the selected view has enough room for legible text.");
+      const linkedCorrelation = definition.id === "correlation-heatmap";
+      if (linkedCorrelation && settings.clusterRows !== settings.clusterColumns) errors.push("Correlation heatmap row and column clustering must be enabled or disabled together because both axes represent the same variables.");
+      const rowCutCount = settings.heatmapRowClusters;
+      const columnCutCount = linkedCorrelation ? rowCutCount : settings.heatmapColumnClusters;
+      const canCluster = definition.id !== "heatmap";
+      const clusterRows = linkedCorrelation ? settings.clusterRows && settings.clusterColumns : settings.clusterRows;
+      const clusterColumns = linkedCorrelation ? settings.clusterRows && settings.clusterColumns : settings.clusterColumns;
+      const showRowCut = canCluster && clusterRows && rowCutCount > 1;
+      const showColumnCut = canCluster && clusterColumns && columnCutCount > 1;
+      const showDendrograms = settings.heatmapDisplay === "rectangular" && canCluster && settings.heatmapShowDendrograms;
+      const layout = heatmapLayoutMetrics(settings, {
+        hasAnnotationLegend: annotationTracks.length > 0,
+        rowAnnotationTracks: rowAnnotations.tracks.length,
+        columnAnnotationTracks: columnAnnotations.tracks.length,
+        showRowCut,
+        showColumnCut,
+        showRowDendrogram: showDendrograms && clusterRows,
+        showColumnDendrogram: showDendrograms && clusterColumns,
+        showSidePlot: settings.heatmapDisplay === "rectangular" && settings.heatmapShowSidePlot,
+        rowCount: displayedRowIds.length,
+        columnCount: numericHeaders.length,
+        maxColumnLabelCharacters: Math.max(0, ...numericHeaders.map((label) => label.length)),
+        maxCutClusters: Math.max(showRowCut ? Math.min(rowCutCount, displayedRowIds.length) : 0, showColumnCut ? Math.min(columnCutCount, numericHeaders.length) : 0),
+      });
+      if (settings.heatmapDisplay === "circular") {
+        if (layout.circularOuterRadius <= layout.circularInnerRadius) errors.push(`Circular heatmap tracks do not fit inside the ${settings.width} × ${settings.height} export after labels, annotation rings, and legends; increase the figure size or reduce annotations.`);
+        if (layout.circularRingWidth < 0.75) errors.push(`Circular heatmap rings would be ${Math.max(0, layout.circularRingWidth).toFixed(2)} px at ${settings.width} × ${settings.height}; reduce rows or increase the figure size.`);
+        else if (layout.circularRingWidth < 1.5) warnings.push(`Circular heatmap rings are approximately ${layout.circularRingWidth.toFixed(1)} px; increase the figure size or reduce rows for reliable print reproduction.`);
+        if (layout.circularSectorArc < 0.75) errors.push(`Circular heatmap sectors would be ${layout.circularSectorArc.toFixed(2)} px along the outer arc; reduce columns or increase the figure size.`);
+        if (settings.heatmapLabelDensity === "all") {
+          const requiredRingListHeight = displayedRowIds.length * (Math.max(8, settings.legendSize) + 3);
+          if (requiredRingListHeight > layout.circularRingListAvailableHeight) errors.push(`All ${displayedRowIds.length} ring identities need ${requiredRingListHeight.toFixed(0)} px, but only ${layout.circularRingListAvailableHeight.toFixed(0)} px is available; use Auto label density, increase height, or reduce rows.`);
+        }
+        if (layout.cutLegendWidth > layout.frame.plotWidth) errors.push(`The cluster-cut legend needs ${layout.cutLegendWidth.toFixed(0)} px of width, but the circular plot frame has ${layout.frame.plotWidth.toFixed(0)} px; increase width, reduce the cut count, or reduce legend size.`);
+      } else {
+        if (layout.matrixWidth < 70) errors.push(`The heatmap matrix has only ${Math.max(0, layout.matrixWidth).toFixed(0)} px of usable width after dendrograms, annotations, legends, and the side plot; increase width or hide optional layers (minimum 70 px).`);
+        if (layout.matrixHeight < 70) errors.push(`The heatmap matrix has only ${Math.max(0, layout.matrixHeight).toFixed(0)} px of usable height after dendrograms, annotations, and legends; increase height or hide optional layers (minimum 70 px).`);
+        if (layout.cutLegendWidth > Math.max(0, layout.matrixWidth)) errors.push(`The cluster-cut legend needs ${layout.cutLegendWidth.toFixed(0)} px, but the matrix header has ${Math.max(0, layout.matrixWidth).toFixed(0)} px; increase width, reduce the cut count, or reduce legend size.`);
+      }
+      if (settings.heatmapRowClusters > displayedRowIds.length) warnings.push(`Row cluster cut is capped at ${displayedRowIds.length}, the number of displayed rows.`);
+      if (columnCutCount > numericHeaders.length) warnings.push(`Column cluster cut is capped at ${numericHeaders.length}, the number of displayed columns.`);
+    }
     return { errors, warnings };
   }
 

--- a/tests/e2e/visualization-studio.spec.ts
+++ b/tests/e2e/visualization-studio.spec.ts
@@ -138,8 +138,76 @@ test.describe("Visualization Studio browser acceptance", () => {
     await paletteToggle.click();
     await expect(paletteToggle).toHaveAttribute("aria-expanded", "true");
 
-    const previewCard = page.getByRole("heading", { name: "Correlation heatmap preview" }).locator("xpath=ancestor::section");
-    await expectStablePreviewScreenshot(page, previewCard, "correlation-heatmap-mobile.png");
+    const heatmapSvg = page.locator("svg[aria-label='Correlation heatmap scientific figure preview']");
+    await expect(heatmapSvg).toHaveAttribute("data-plot-renderer", "advanced");
+    const escapedLabels = await heatmapSvg.evaluate((element) => {
+      const canvas = element.getBoundingClientRect();
+      return [...element.querySelectorAll("text")].flatMap((label) => {
+        const box = label.getBoundingClientRect();
+        return box.left < canvas.left - 1 || box.top < canvas.top - 1 || box.right > canvas.right + 1 || box.bottom > canvas.bottom + 1 ? [label.textContent] : [];
+      });
+    });
+    expect(escapedLabels).toEqual([]);
+  });
+
+  test("configures reproducible heatmap structure without clipping the compact export", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop-chromium", "Desktop heatmap controls");
+    await page.goto("/");
+    await page.getByRole("button", { name: /^Clustered heatmap/ }).click();
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const svg = page.locator("svg[aria-label='Clustered heatmap scientific figure preview']");
+    await expect(svg).toHaveAttribute("data-plot-renderer", "advanced");
+    await expect(svg.locator("[data-plot-element='dendrogram']")).not.toHaveCount(0);
+    await expect(svg.locator("[data-cluster-cut='row']")).not.toHaveCount(0);
+
+    await page.getByRole("textbox", { name: "Column annotations (TSV)" }).fill("id\tgroup\nControl_1\tControl\nTreatment_1\tTreatment\nExtra\tUnknown");
+    await expect(page.getByText(/column IDs are missing from the annotation table/)).toBeVisible();
+    await expect(page.getByText(/annotation ID does not match the matrix/)).toBeVisible();
+    await expect(svg.locator("[data-annotation-target='column']")).toHaveCount(12);
+
+    await page.getByRole("textbox", { name: "Width value", exact: true }).fill("520");
+    await page.getByRole("textbox", { name: "Height value", exact: true }).fill("420");
+    await page.getByRole("combobox", { name: "Layout" }).selectOption("circular");
+    await expect(svg.locator("[data-plot-family='circular-heatmap']")).toBeVisible();
+    const escapedCircularText = await svg.evaluate((element) => {
+      const canvas = element.getBoundingClientRect();
+      return [...element.querySelectorAll("[data-plot-family='circular-heatmap'] text")].flatMap((label) => {
+        const box = label.getBoundingClientRect();
+        return box.left < canvas.left - 1 || box.top < canvas.top - 1 || box.right > canvas.right + 1 || box.bottom > canvas.bottom + 1 ? [label.textContent] : [];
+      });
+    });
+    expect(escapedCircularText).toEqual([]);
+
+    const manyRows = ["gene\tA\tB\tC", ...Array.from({ length: 20 }, (_, index) => `G${index}\t${index + 1}\t${index + 2}\t${index + 3}`)].join("\n");
+    await page.getByRole("textbox", { name: "Column annotations (TSV)" }).fill("");
+    await page.getByRole("textbox", { name: "CSV or TSV data" }).fill(manyRows);
+    await page.getByRole("textbox", { name: "Width value", exact: true }).fill("340");
+    await page.getByRole("textbox", { name: "Height value", exact: true }).fill("340");
+    await page.getByRole("textbox", { name: "Legend size value", exact: true }).fill("16");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const escapedLargeLegendText = await svg.evaluate((element) => {
+      const canvas = element.getBoundingClientRect();
+      return [...element.querySelectorAll("[data-plot-family='circular-heatmap'] text")].flatMap((label) => {
+        const box = label.getBoundingClientRect();
+        return box.left < canvas.left - 1 || box.top < canvas.top - 1 || box.right > canvas.right + 1 || box.bottom > canvas.bottom + 1 ? [label.textContent] : [];
+      });
+    });
+    expect(escapedLargeLegendText).toEqual([]);
+
+    await page.getByRole("textbox", { name: "Width value", exact: true }).fill("520");
+    await page.getByRole("textbox", { name: "Height value", exact: true }).fill("420");
+    await page.getByRole("combobox", { name: "Layout" }).selectOption("rectangular");
+    await page.getByText("Coordinated raw-value row summary", { exact: true }).click();
+    await expect(svg.locator("[data-plot-element='heatmap-side-plot']")).toBeVisible();
+
+    const escapedGeometry = await svg.evaluate((element) => {
+      const canvas = element.getBoundingClientRect();
+      return [...element.querySelectorAll("[data-plot-element='heatmap-cell'], [data-plot-element='dendrogram'], [data-annotation-target]")].flatMap((mark) => {
+        const box = mark.getBoundingClientRect();
+        return box.left < canvas.left - 1 || box.top < canvas.top - 1 || box.right > canvas.right + 1 || box.bottom > canvas.bottom + 1 ? [mark.getAttribute("data-plot-element") ?? mark.getAttribute("data-annotation-target")] : [];
+      });
+    });
+    expect(escapedGeometry).toEqual([]);
   });
 
   test("switches categorical variants and computes long-form uncertainty", async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary
- add explicit row/column scaling, deterministic hierarchical clustering, dendrograms, linked correlation ordering, and reproducible cluster cuts
- add stable-ID row/column annotations with declared categorical or continuous types, mismatch reporting, static legends, and unique deterministic colors
- add triangular correlation, bounded circular heatmaps, raw-value side summaries, dynamic label density, and restrained sequential/diverging palettes
- share exact heatmap geometry between validation and rendering so dense or compact exports fail with actionable guidance instead of clipping
- document the heatmap data contract and scientific reference

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm test -- --run` (76 tests)
- `npm run test:e2e` (10 passed, 4 intentional device-specific skips)
- `npm run build -- --webpack`
- dual independent review: Clean / Clean

Closes #9