### PR TITLE
Issue #10: extend dimension-reduction and sample-structure views

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ A browser-local scientific visualization workspace for creating compact, publica
 ## Highlights
 
 - Publication-oriented defaults with Arial typography and compact figure dimensions
-- Forty-three registry-owned modules, including categorical comparison, distribution, dimension reduction, enrichment, survival, set, network, genomic, composition, hierarchy, cyclic profile, and paired-distribution families
+- Forty-five registry-owned modules, including categorical comparison, distribution, dimension reduction, enrichment, survival, set, network, genomic, composition, hierarchy, cyclic profile, and paired-distribution families
 - Distinct pie, donut, rose, waffle, treemap, sunburst, radar, polar-profile, and population-pyramid contracts with scientific suitability guidance and references
 - A unified Box, Violin, Beeswarm, Raincloud, Histogram, Density, and Ridge layer system with deterministic binning, KDE, quartiles, SD, SEM, Student t confidence intervals, pairing, facets, and orientation controls
 - Line uncertainty as pointwise SD, SEM, or supplied 95% CI half-widths, displayed as bars or ribbons
 - Association views spanning points, marginals, 2D density, hexbin counts, covariance ellipses, convex hulls, three-variable pair matrices, orthographic 3D, and ternary compositions, with linear, polynomial, or LOESS fits
+- A unified PCA, PCoA, UMAP, t-SNE, and NMDS display system with color/shape mappings, covariance ellipses, convex hulls, centroids, optional orthographic 3D, supplied PERMANOVA annotations, and PCA scree/loading views
 - Heatmaps with row/column z-scaling, Euclidean or correlation distance, average/complete/single linkage, dendrograms, reproducible cluster cuts, stable-ID annotation tracks, triangular correlations, circular layouts, and coordinated row summaries
 - Adjustable labels, dimensions, line weights, marks, grids, legends, uncertainty bars, palettes, and plot-specific parameters
 - Built-in journal-inspired and traditional Chinese color palettes
@@ -43,6 +44,10 @@ The application focuses on visualization and deterministic browser-side transfor
 ### Heatmap data contract
 
 Heatmap matrices use the first column as a unique row identifier and all remaining columns as numeric matrix values. Optional row and column annotation tables are TSV/CSV text whose first column contains stable identifiers; they are joined by exact ID rather than row order. Declare track semantics in headers such as `batch[categorical]` or `age[continuous]`; undeclared numeric tracks are inferred as continuous with an explicit warning. Duplicate identifiers and invalid continuous declarations block rendering, while missing and extra identifiers are reported explicitly. Browser previews are capped at 250 × 100 cells for rectangular layouts and 80 × 60 for circular layouts, with an additional size-aware minimum ring-width check. Scaling, distance, linkage, cluster-cut counts, view mode, and palettes are preserved in the JSON configuration export.
+
+### Ordination data contract
+
+PCA accepts a wide feature-by-observation matrix plus optional observation metadata joined by exact sample ID, and records filtering, transformation, centering, optional feature scaling, explained variance, scores, and all selected-feature loadings. Auto detection is deliberately conservative: only `_count`/`_counts` and `_tpm`/`_fpkm` column suffixes select a raw-count or abundance transform; other numeric matrices are treated as already normalized unless the user explicitly chooses a layer. Counts use `log2(CPM + 1)` after a documented low-count filter, non-negative abundance uses `log2(value + 1)`, and normalized continuous data are not silently transformed. PCA uses a deterministic NIPALS solver and is capped at 300 observations and one million selected feature-by-observation cells in the browser; larger studies should import externally computed, documented coordinates. PCoA, UMAP, t-SNE, and NMDS accept precomputed coordinates only and never refit an embedding in the browser. A third coordinate is required only for the optional orthographic 3D projection, whose independently min-max-scaled axes are descriptive rather than metric. Compact ordination legends support up to 12 color groups. PCoA variance percentages, NMDS stress, upstream method notes, and PERMANOVA statistics are displayed only when supplied; PERMANOVA requires a tested group and a method note and is not recomputed from plotted coordinates. Preserve the upstream distance, preprocessing, random seed, constraints/strata, and convergence settings in the analysis record.
 
 ## Privacy
 

--- a/src/components/ScientificAdvancedChartPreview.tsx
+++ b/src/components/ScientificAdvancedChartPreview.tsx
@@ -20,6 +20,7 @@ import {
   categoricalColorForIndex,
   boxStatistics,
   confidenceInterval95,
+  compactLegendLabel,
   covarianceEllipsePoints,
   deterministicBeeswarmLayout,
   deterministicHistogram,
@@ -36,12 +37,18 @@ import {
   loessSmooth,
   meanErrorStatistics,
   numericExtent,
+  ordinationAnnotationLayout,
+  ordinationFrameMetrics,
+  ordinationLegendLayout,
+  ordinationLoadingLayout,
+  ordinationScoreDomains,
   parseNumericValue,
   parseRatioValue,
   polynomialRegression,
   resolveAxisDomain,
   scaleLinear,
   type JournalThemeId,
+  type OrdinationType,
   type ParsedDataset,
   type PlotType,
   type VisualizationSettings,
@@ -78,7 +85,7 @@ function frameFor(type: PlotType, settings: VisualizationSettings): Frame {
 }
 
 function palette(groups: string[], colors: string[]) {
-  return new Map(groups.map((group, index) => [group, colors[index % Math.max(1, colors.length)]]));
+  return new Map(groups.map((group, index) => [group, categoricalColorForIndex(index, colors)]));
 }
 
 function tickValues(domain: [number, number], count = 5) {
@@ -111,9 +118,10 @@ function Legend({ entries, frame, settings }: { entries: LegendEntry[]; frame: F
     const visible = entries.slice(0, 12);
     const perRow = Math.max(2, Math.min(4, Math.floor(frame.plotWidth / 90)));
     const cellWidth = frame.plotWidth / perRow;
-    return <g transform={`translate(${frame.left} ${frame.height - 72})`}>{visible.map((entry, index) => <g key={entry.label} transform={`translate(${(index % perRow) * cellWidth} ${Math.floor(index / perRow) * (settings.legendSize + 7)})`}><circle cx={4} cy={-4} r={4} fill={entry.color} /><text x={13} y={0} fill={TEXT} fontSize={settings.legendSize}>{entry.label.slice(0, 15)}</text></g>)}</g>;
+    return <g data-plot-element="plot-legend" transform={`translate(${frame.left} ${frame.height - 72})`}>{visible.map((entry, index) => <g key={entry.label} transform={`translate(${(index % perRow) * cellWidth} ${Math.floor(index / perRow) * (settings.legendSize + 7)})`}><circle cx={4} cy={-4} r={4} fill={entry.color} /><text data-full-label={entry.label} x={13} y={0} fill={TEXT} fontSize={settings.legendSize}><title>{entry.label}</title>{compactLegendLabel(entry.label, settings.legendSize, cellWidth - 17, 15)}</text></g>)}</g>;
   }
-  return <g transform={`translate(${frame.left + frame.plotWidth + 18} ${frame.top + 5})`}>{entries.slice(0, 12).map((entry, index) => <g key={entry.label} transform={`translate(0 ${index * (settings.legendSize + 10)})`}><circle cx={4} cy={-4} r={4} fill={entry.color} /><text x={13} y={0} fill={TEXT} fontSize={settings.legendSize}>{entry.label.slice(0, 24)}</text></g>)}</g>;
+  const availableLabelWidth = frame.width - (frame.left + frame.plotWidth + 18) - 13 - 4;
+  return <g data-plot-element="plot-legend" transform={`translate(${frame.left + frame.plotWidth + 18} ${frame.top + 5})`}>{entries.slice(0, 12).map((entry, index) => <g key={entry.label} transform={`translate(0 ${index * (settings.legendSize + 10)})`}><circle cx={4} cy={-4} r={4} fill={entry.color} /><text data-full-label={entry.label} x={13} y={0} fill={TEXT} fontSize={settings.legendSize}><title>{entry.label}</title>{compactLegendLabel(entry.label, settings.legendSize, availableLabelWidth, 24)}</text></g>)}</g>;
 }
 
 type AssociationPoint = { x: number; y: number; z: number | null; group: string; label: string; index: number };
@@ -237,6 +245,116 @@ function ScatterFamily({ type, frame, dataset, mapping, settings, colors, gridCo
     {type === "correlation" ? <text x={frame.left + 10} y={frame.top + 18} fill={TEXT} fontSize={settings.legendSize} fontWeight={700}>{settings.correlationMethod === "pearson" ? "Pearson r" : "Spearman ρ"} = {coefficient.toFixed(3)} · n = {points.length}</text> : null}
     <Legend entries={groups.map((group) => ({ label: group, color: colorMap.get(group) ?? colors[0] }))} frame={frame} settings={settings} />
   </>;
+}
+
+function OrdinationMark({ x, y, radius, shapeIndex, color, opacity }: { x: number; y: number; radius: number; shapeIndex: number; color: string; opacity: number }) {
+  const shape = shapeIndex % 4;
+  if (shape === 1) return <rect data-plot-element="ordination-point" data-shape="square" x={x - radius * 0.86} y={y - radius * 0.86} width={radius * 1.72} height={radius * 1.72} rx={0.8} fill={color} fillOpacity={opacity} stroke="#FFFFFF" strokeWidth={0.7} />;
+  if (shape === 2) return <polygon data-plot-element="ordination-point" data-shape="triangle" points={`${x},${y - radius} ${x + radius * 0.92},${y + radius * 0.8} ${x - radius * 0.92},${y + radius * 0.8}`} fill={color} fillOpacity={opacity} stroke="#FFFFFF" strokeWidth={0.7} />;
+  if (shape === 3) return <polygon data-plot-element="ordination-point" data-shape="diamond" points={`${x},${y - radius} ${x + radius},${y} ${x},${y + radius} ${x - radius},${y}`} fill={color} fillOpacity={opacity} stroke="#FFFFFF" strokeWidth={0.7} />;
+  return <circle data-plot-element="ordination-point" data-shape="circle" cx={x} cy={y} r={radius} fill={color} fillOpacity={opacity} stroke="#FFFFFF" strokeWidth={0.7} />;
+}
+
+function OrdinationShapeLegend({ shapes, shapeMap, settings, layout }: { shapes: string[]; shapeMap: Map<string, number>; settings: VisualizationSettings; layout: ReturnType<typeof ordinationLegendLayout> }) {
+  if (!settings.ordinationUseShapes || shapes.length < 2 || settings.legendPosition === "none") return null;
+  const fontSize = Math.max(8, settings.legendSize - 1);
+  const availableLabelWidth = settings.legendPosition === "right" ? settings.width - layout.shapeX - 12 - 4 : 62;
+  return <g data-plot-element="ordination-shape-legend" transform={`translate(${layout.shapeX} ${layout.shapeY})`}><text x={0} y={0} fill={TEXT} fontSize={fontSize} fontWeight={700}>Shape</text>{shapes.slice(0, 4).map((shape, index) => <g key={shape} transform={`translate(${settings.legendPosition === "right" ? 0 : index * 74} ${settings.legendPosition === "right" ? 9 + index * (settings.legendSize + 6) : 9})`}><OrdinationMark x={4} y={4} radius={4} shapeIndex={shapeMap.get(shape) ?? 0} color={TEXT} opacity={0.85} /><text data-full-label={shape} x={12} y={8} fill={TEXT} fontSize={fontSize}><title>{shape}</title>{compactLegendLabel(shape, fontSize, availableLabelWidth, 10)}</text></g>)}</g>;
+}
+
+function OrdinationLabel({ x, y, radius, label, frame, fontSize }: { x: number; y: number; radius: number; label: string; frame: Frame; fontSize: number }) {
+  const fullText = label.slice(0, 12);
+  const rightSpace = frame.left + frame.plotWidth - x - radius - 3;
+  const leftSpace = x - frame.left - radius - 3;
+  const fullWidth = fullText.length * fontSize;
+  const side = rightSpace >= fullWidth ? "right" : leftSpace >= fullWidth ? "left" : "center";
+  const centeredCapacity = Math.max(1, Math.floor((frame.plotWidth - 6) / fontSize));
+  const capacity = side === "center" ? centeredCapacity : Math.max(1, Math.floor((side === "right" ? rightSpace : leftSpace) / fontSize));
+  const text = fullText.length <= capacity ? fullText : capacity > 1 ? `${fullText.slice(0, capacity - 1)}…` : "…";
+  const estimatedWidth = text.length * fontSize;
+  const labelX = side === "right" ? x + radius + 2 : side === "left" ? x - radius - 2 : Math.max(frame.left + estimatedWidth / 2 + 2, Math.min(frame.left + frame.plotWidth - estimatedWidth / 2 - 2, x));
+  const textAnchor = side === "right" ? "start" : side === "left" ? "end" : "middle";
+  const placeAbove = y - fontSize - 3 >= frame.top;
+  const labelY = placeAbove ? y - 3 : Math.min(frame.top + frame.plotHeight - 2, y + fontSize + 2);
+  return <text data-plot-label data-full-label={label} x={labelX} y={labelY} textAnchor={textAnchor} fill={TEXT} fontSize={fontSize}><title>{label}</title>{text}</text>;
+}
+
+function OrdinationPlot({ type, frame, dataset, mapping, settings, colors, gridColor }: { type: OrdinationType; frame: Frame; dataset: ParsedDataset; mapping: Record<string, string>; settings: VisualizationSettings; colors: string[]; gridColor: string }) {
+  const explainedVariance = dataset.analysis?.pca?.explainedVariance ?? [];
+  if (type === "pca" && settings.ordinationView === "scree") {
+    const values = explainedVariance.slice(0, 10);
+    const yDomain = numericExtent([0, ...values.map((value) => value * 100)], true);
+    const band = frame.plotWidth / Math.max(1, values.length);
+    const positions = values.map((_, index) => frame.left + (index + 0.5) * band);
+    const yAt = (value: number) => scaleLinear(value, yDomain, [frame.top + frame.plotHeight, frame.top]);
+    return <><Axes frame={frame} settings={settings} xDomain={[0, values.length]} yDomain={yDomain} xLabel={settings.xLabel || "Principal component"} yLabel={settings.yLabel || "Explained variance (%)"} gridColor={gridColor} hideXTicks categoryXPositions={positions} /><g data-plot-data data-plot-family="ordination-scree">{values.map((value, index) => { const x = frame.left + index * band + band * 0.16; const y = yAt(value * 100); return <g key={index}><rect data-plot-element="scree-bar" x={x} y={y} width={band * 0.68} height={frame.top + frame.plotHeight - y} rx={1.5} fill={colors[index % colors.length]} fillOpacity={settings.opacity} /><circle data-plot-element="scree-point" cx={x + band * 0.34} cy={y} r={Math.max(2.2, settings.pointSize * 0.58)} fill={TEXT} /><text x={x + band * 0.34} y={frame.top + frame.plotHeight + 17} textAnchor="middle" fill={TEXT} fontSize={settings.tickSize}>PC{index + 1}</text><text x={x + band * 0.34} y={Math.max(frame.top + settings.tickSize, y - 5)} textAnchor="middle" fill={TEXT} fontSize={Math.max(8, settings.tickSize - 1)}>{(value * 100).toFixed(1)}%</text></g>; })}{values.length > 1 ? <polyline data-plot-element="scree-line" points={values.map((value, index) => `${frame.left + (index + 0.5) * band},${yAt(value * 100)}`).join(" ")} fill="none" stroke={TEXT} strokeWidth={settings.dataLineWidth} /> : null}</g></>;
+  }
+
+  const annotation = ordinationAnnotationLayout(type, settings);
+  const annotationLines = annotation.lines;
+  const annotationFontSize = annotation.fontSize;
+  const annotationLineHeight = annotation.lineHeight;
+  const sharedFrame = ordinationFrameMetrics(type, settings);
+  const chartFrame: Frame = sharedFrame;
+  const scoreDomains = ordinationScoreDomains(type, dataset, mapping, settings);
+  const displayedXColumn = scoreDomains.displayedXColumn;
+  const displayedYColumn = scoreDomains.displayedYColumn;
+  const rawPoints = dataset.rows.map((row, index) => ({
+    x: parseNumericValue(row[displayedXColumn]) ?? 0,
+    y: parseNumericValue(row[displayedYColumn]) ?? 0,
+    z: mapping.z ? parseNumericValue(row[mapping.z]) ?? 0 : 0,
+    group: mapping.group ? row[mapping.group] || "All" : "All",
+    shape: settings.ordinationUseShapes && mapping.shape ? row[mapping.shape] || "All" : "All",
+    label: mapping.label ? row[mapping.label] || "" : "",
+    index,
+  }));
+  const groups = [...new Set(rawPoints.map((point) => point.group))];
+  const shapes = [...new Set(rawPoints.map((point) => point.shape))];
+  const ordinationLegend = ordinationLegendLayout(type, settings, groups.length, shapes.length);
+  const colorMap = palette(groups, colors);
+  const shapeMap = new Map(shapes.map((shape, index) => [shape, index]));
+  const componentIndex = (header: string) => Math.max(0, Number(header.match(/\d+/)?.[0] ?? 1) - 1);
+  const defaultAxis = (axis: 1 | 2 | 3) => type === "pca" ? `PC${axis}` : type === "pcoa" ? `PCoA ${axis}` : type === "umap" ? `UMAP ${axis}` : type === "tsne" ? `t-SNE ${axis}` : `NMDS ${axis}`;
+  const axisLabel = (axis: 1 | 2 | 3) => {
+    const custom = axis === 1 ? settings.xLabel : axis === 2 ? settings.yLabel : "";
+    if (custom) return custom;
+    if (type === "pca") {
+      const componentColumn = axis === 1 ? displayedXColumn : axis === 2 ? displayedYColumn : mapping.z;
+      const component = componentIndex(componentColumn);
+      const explained = explainedVariance[component];
+      return `${componentColumn || defaultAxis(axis)}${Number.isFinite(explained) ? ` (${(explained * 100).toFixed(1)}%)` : ""}`;
+    }
+    const coordinateColumn = axis === 1 ? mapping.x : axis === 2 ? mapping.y : mapping.z;
+    const numberMatch = coordinateColumn?.match(/(?:^|[_ .-])(?:dim|axis|component|pc|pcoa|umap|tsne|nmds)[_ .-]?(\d+)$/i);
+    const coordinateNumber = numberMatch ? Math.max(1, Number(numberMatch[1])) : axis;
+    const mappedLabel = numberMatch
+      ? type === "pcoa" ? `PCoA ${coordinateNumber}` : type === "umap" ? `UMAP ${coordinateNumber}` : type === "tsne" ? `t-SNE ${coordinateNumber}` : `NMDS ${coordinateNumber}`
+      : coordinateColumn || defaultAxis(axis);
+    const suppliedVariance = [settings.ordinationXVariance, settings.ordinationYVariance, settings.ordinationZVariance][coordinateNumber - 1] ?? null;
+    return `${mappedLabel}${type === "pcoa" && suppliedVariance !== null ? ` (${suppliedVariance.toFixed(1)}%)` : ""}`;
+  };
+
+  if (settings.ordinationView === "3d") {
+    const xExtent = numericExtent(rawPoints.map((point) => point.x)); const yExtent = numericExtent(rawPoints.map((point) => point.y)); const zExtent = numericExtent(rawPoints.map((point) => point.z));
+    const project = (point: { x: number; y: number; z: number }) => { const nx = scaleLinear(point.x, xExtent, [-1, 1]); const ny = scaleLinear(point.y, yExtent, [-1, 1]); const nz = scaleLinear(point.z, zExtent, [-1, 1]); return { x: chartFrame.left + chartFrame.plotWidth * (0.5 + nx * 0.34 + nz * 0.13), y: chartFrame.top + chartFrame.plotHeight * (0.5 - ny * 0.34 + nz * 0.1) }; };
+    const projected = rawPoints.map((point) => ({ ...point, ...project(point) }));
+    const centroids = groups.map((group) => { const members = rawPoints.filter((point) => point.group === group); const centroid = { x: members.reduce((sum, point) => sum + point.x, 0) / members.length, y: members.reduce((sum, point) => sum + point.y, 0) / members.length, z: members.reduce((sum, point) => sum + point.z, 0) / members.length }; return { group, ...project(centroid) }; });
+    return <>{annotationLines.map((line, index) => <text key={`${index}-${line}`} x={14} y={sharedFrame.annotationTop + (index + 1) * annotationLineHeight - 4} fill={TEXT} fontSize={annotationFontSize}>{line}</text>)}<g data-plot-data data-plot-family="ordination-3d"><rect x={chartFrame.left} y={chartFrame.top} width={chartFrame.plotWidth} height={chartFrame.plotHeight} fill="none" stroke={gridColor} /><path d={`M ${chartFrame.left + 20} ${chartFrame.top + chartFrame.plotHeight - 20} l 42 0 m -42 0 l 0 -42 m 0 42 l 24 18`} fill="none" stroke={TEXT} strokeWidth={settings.axisLineWidth} /><text x={chartFrame.left + 66} y={chartFrame.top + chartFrame.plotHeight - 16} fill={TEXT} fontSize={settings.tickSize}>{axisLabel(1)}</text><text x={chartFrame.left + 4} y={chartFrame.top + chartFrame.plotHeight - 67} fill={TEXT} fontSize={settings.tickSize}>{axisLabel(2)}</text><text x={chartFrame.left + 47} y={chartFrame.top + chartFrame.plotHeight + 2} fill={TEXT} fontSize={settings.tickSize}>{axisLabel(3)}</text>{projected.map((point) => <g key={point.index}><OrdinationMark x={point.x} y={point.y} radius={settings.pointSize} shapeIndex={shapeMap.get(point.shape) ?? 0} color={colorMap.get(point.group) ?? colors[0]} opacity={settings.opacity} />{settings.showLabels && point.label ? <OrdinationLabel x={point.x} y={point.y} radius={settings.pointSize} label={point.label} frame={chartFrame} fontSize={settings.tickSize} /> : null}</g>)}{settings.ordinationShowCentroids ? centroids.map((centroid) => <g key={centroid.group} data-plot-element="ordination-centroid"><line x1={centroid.x - 5} x2={centroid.x + 5} y1={centroid.y} y2={centroid.y} stroke={colorMap.get(centroid.group)} strokeWidth={2} /><line x1={centroid.x} x2={centroid.x} y1={centroid.y - 5} y2={centroid.y + 5} stroke={colorMap.get(centroid.group)} strokeWidth={2} /></g>) : null}</g><Legend entries={groups.map((group) => ({ label: group, color: colorMap.get(group) ?? colors[0] }))} frame={chartFrame} settings={settings} /><OrdinationShapeLegend shapes={shapes} shapeMap={shapeMap} settings={settings} layout={ordinationLegend} /></>;
+  }
+
+  const buckets = groups.map((group) => ({ group, points: rawPoints.filter((point) => point.group === group), color: colorMap.get(group) ?? colors[0] }));
+  const ellipses = settings.ordinationShowEllipse ? buckets.map((bucket) => ({ ...bucket, ellipse: covarianceEllipsePoints(bucket.points) })) : [];
+  const hulls = settings.ordinationShowHull ? buckets.map((bucket) => ({ ...bucket, hull: convexHull(bucket.points) })) : [];
+  const { xDomain, yDomain } = scoreDomains;
+  const xAt = (value: number) => scaleLinear(value, xDomain, [chartFrame.left, chartFrame.left + chartFrame.plotWidth]); const yAt = (value: number) => scaleLinear(value, yDomain, [chartFrame.top + chartFrame.plotHeight, chartFrame.top]);
+  const centroids = buckets.map((bucket) => ({ group: bucket.group, color: bucket.color, x: bucket.points.reduce((sum, point) => sum + point.x, 0) / bucket.points.length, y: bucket.points.reduce((sum, point) => sum + point.y, 0) / bucket.points.length }));
+  const loadingLayout = settings.ordinationShowLoadings && type === "pca" ? ordinationLoadingLayout(dataset, mapping, settings) : null;
+  const originX = loadingLayout?.originX ?? xAt(0);
+  const originY = loadingLayout?.originY ?? yAt(0);
+  const loadingFontSize = loadingLayout?.fontSize ?? Math.max(8, settings.tickSize - 1);
+  const loadingSafetyScale = loadingLayout?.safetyScale ?? 1;
+  const loadingGeometries = loadingLayout?.geometries ?? [];
+  return <>{annotationLines.map((line, index) => <text key={`${index}-${line}`} x={14} y={sharedFrame.annotationTop + (index + 1) * annotationLineHeight - 4} fill={TEXT} fontSize={annotationFontSize}>{line}</text>)}<Axes frame={chartFrame} settings={settings} xDomain={xDomain} yDomain={yDomain} xLabel={axisLabel(1)} yLabel={axisLabel(2)} gridColor={gridColor} /><g data-plot-data data-plot-family="ordination-scores"><defs><marker id={`ordination-arrow-${type}`} markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill={TEXT} /></marker></defs>{hulls.map((entry) => entry.hull.length >= 3 ? <polygon key={entry.group} data-plot-element="ordination-hull" points={entry.hull.map((point) => `${xAt(point.x)},${yAt(point.y)}`).join(" ")} fill={entry.color} fillOpacity={0.08} stroke={entry.color} strokeWidth={settings.dataLineWidth} /> : null)}{ellipses.map((entry) => entry.ellipse.length ? <polyline key={entry.group} data-plot-element="ordination-ellipse" points={entry.ellipse.map((point) => `${xAt(point.x)},${yAt(point.y)}`).join(" ")} fill={entry.color} fillOpacity={0.07} stroke={entry.color} strokeWidth={settings.dataLineWidth} /> : null)}{rawPoints.map((point) => { const x = xAt(point.x); const y = yAt(point.y); return <g key={point.index}><OrdinationMark x={x} y={y} radius={settings.pointSize} shapeIndex={shapeMap.get(point.shape) ?? 0} color={colorMap.get(point.group) ?? colors[0]} opacity={settings.opacity} />{settings.showLabels && point.label ? <OrdinationLabel x={x} y={y} radius={settings.pointSize} label={point.label} frame={chartFrame} fontSize={settings.tickSize} /> : null}</g>; })}{settings.ordinationShowCentroids ? centroids.map((centroid) => <g key={centroid.group} data-plot-element="ordination-centroid"><line x1={xAt(centroid.x) - 5} x2={xAt(centroid.x) + 5} y1={yAt(centroid.y)} y2={yAt(centroid.y)} stroke={centroid.color} strokeWidth={2} /><line x1={xAt(centroid.x)} x2={xAt(centroid.x)} y1={yAt(centroid.y) - 5} y2={yAt(centroid.y) + 5} stroke={centroid.color} strokeWidth={2} /><text x={xAt(centroid.x) + 7} y={yAt(centroid.y) - 5} fill={centroid.color} fontSize={Math.max(8, settings.tickSize - 1)}>{centroid.group.slice(0, 10)}</text></g>) : null}{loadingGeometries.map((loading) => { const placeBelow = loading.endY - loadingFontSize < chartFrame.top + 2; return <g key={loading.feature} data-plot-element="ordination-loading" data-loading-scale={loadingSafetyScale.toFixed(4)}><line x1={originX} y1={originY} x2={loading.endX} y2={loading.endY} stroke={TEXT} strokeWidth={Math.max(0.8, settings.dataLineWidth * 0.7)} markerEnd={`url(#ordination-arrow-${type})`} /><text x={loading.endX + (loading.endX >= originX ? 3 : -3)} y={loading.endY + (placeBelow ? loadingFontSize + 2 : -3)} textAnchor={loading.endX >= originX ? "start" : "end"} fill={TEXT} fontSize={loadingFontSize}><title>{loading.feature}</title>{loading.displayFeature}</text></g>; })}</g><Legend entries={groups.map((group) => ({ label: group, color: colorMap.get(group) ?? colors[0] }))} frame={chartFrame} settings={settings} /><OrdinationShapeLegend shapes={shapes} shapeMap={shapeMap} settings={settings} layout={ordinationLegend} /></>;
 }
 
 function MaPlot({ frame, dataset, mapping, settings, colors, gridColor }: { frame: Frame; dataset: ParsedDataset; mapping: Record<string, string>; settings: VisualizationSettings; colors: string[]; gridColor: string }) {
@@ -969,7 +1087,8 @@ export function ScientificAdvancedChartPreview({ svgRef, type, dataset, mapping,
   let content: ReactNode = null;
   if (type === "line") content = <LineAssociationPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (type === "scatter" || type === "correlation") content = <AssociationPlot type={type} frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
-  else if (["quadrant", "pcoa", "umap"].includes(type)) content = <ScatterFamily type={type} frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
+  else if (type === "quadrant") content = <ScatterFamily type={type} frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
+  else if (["pca", "pcoa", "umap", "tsne", "nmds"].includes(type)) content = <OrdinationPlot type={type as OrdinationType} frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (type === "ma") content = <MaPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (type === "errorbar") content = <ErrorBarPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (type === "area") content = <AreaPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;

--- a/src/components/VisualizationStudio.tsx
+++ b/src/components/VisualizationStudio.tsx
@@ -231,7 +231,7 @@ function uniqueColumnValues(rows: Array<Record<string, string>>, column: string 
 function categoricalColorLabels(plotType: PlotType, rows: Array<Record<string, string>>, mapping: Record<string, string>) {
   if (plotType === "bar") return uniqueColumnValues(rows, mapping.group, "Value");
   if (plotType === "line" || plotType === "area") return uniqueColumnValues(rows, mapping.series, "All");
-  if (["scatter", "correlation", "quadrant", "pca", "pcoa", "umap", "errorbar", "lollipop", "km", "survival-forest", "roc"].includes(plotType)) return uniqueColumnValues(rows, mapping.group, "All");
+  if (["scatter", "correlation", "quadrant", "pca", "pcoa", "umap", "tsne", "nmds", "errorbar", "lollipop", "km", "survival-forest", "roc"].includes(plotType)) return uniqueColumnValues(rows, mapping.group, "All");
   if (distributionPlotTypes.includes(plotType)) return uniqueColumnValues(rows, mapping.group, "All");
   if (plotType === "volcano" || plotType === "ma") return ["Down", "Up", "Not significant"];
   if (plotType === "gsea") return ["Running ES", "Gene-set hits"];
@@ -425,6 +425,7 @@ export function VisualizationStudio() {
   const [paletteSeriesId, setPaletteSeriesId] = useState<PaletteSeriesId>(defaultVisualizationPaletteSeriesId);
   const [settings, setSettings] = useState<VisualizationSettings>(() => settingsForTheme(defaultVisualizationThemeId));
   const [pcaOptions, setPcaOptions] = useState<PcaOptions>(defaultPcaOptions);
+  const [pcaObservationMetadata, setPcaObservationMetadata] = useState("");
   const [customPalettes, setCustomPalettes] = useState<CustomPalette[]>([]);
   const [selectedCustomPaletteId, setSelectedCustomPaletteId] = useState("");
   const [customPaletteName, setCustomPaletteName] = useState("");
@@ -491,7 +492,7 @@ export function VisualizationStudio() {
   const manualAxes = activeNumericAxes(plotType, settings);
   const invalidXLimits = manualAxes.includes("x") && settings.xMin !== null && settings.xMax !== null && settings.xMin >= settings.xMax;
   const invalidYLimits = manualAxes.includes("y") && settings.yMin !== null && settings.yMax !== null && settings.yMin >= settings.yMax;
-  const pcaAnalysis = useMemo(() => plotType === "pca" ? analyzeExpressionMatrix(rawData, pcaOptions) : null, [plotType, rawData, pcaOptions]);
+  const pcaAnalysis = useMemo(() => plotType === "pca" ? analyzeExpressionMatrix(rawData, pcaOptions, pcaObservationMetadata) : null, [plotType, rawData, pcaObservationMetadata, pcaOptions]);
   const dataset = useMemo(() => pcaAnalysis?.dataset ?? parseDelimitedData(rawData), [pcaAnalysis, rawData]);
   const barBreakRange = useMemo(() => {
     if (plotType !== "bar" || !mapping.value) return { minimum: -100, maximum: 100, step: 0.5 };
@@ -525,10 +526,13 @@ export function VisualizationStudio() {
   const hasUnsavedColorChanges = currentColorFingerprint !== selectedPaletteFingerprint;
   const previewSettings = useMemo(() => {
     if (!pcaAnalysis) return settings;
+    if (settings.ordinationView === "scree") return settings;
+    const displayedX = settings.swapAxes ? mapping.y : mapping.x;
+    const displayedY = settings.swapAxes ? mapping.x : mapping.y;
     return {
       ...settings,
-      xLabel: settings.xLabel || pcaAxisLabel(mapping.x, pcaAnalysis.explainedVariance),
-      yLabel: settings.yLabel || pcaAxisLabel(mapping.y, pcaAnalysis.explainedVariance),
+      xLabel: settings.xLabel || pcaAxisLabel(displayedX, pcaAnalysis.explainedVariance),
+      yLabel: settings.yLabel || pcaAxisLabel(displayedY, pcaAnalysis.explainedVariance),
     };
   }, [mapping.x, mapping.y, pcaAnalysis, settings]);
 
@@ -551,6 +555,7 @@ export function VisualizationStudio() {
     if (!example) return;
     setSelectedExampleIndex(exampleIndex);
     setRawData(example.data);
+    setPcaObservationMetadata(example.metadata ?? "");
     setMapping(example.mapping ?? definition.defaultMapping);
     setLoadedFileName("");
     setFileError("");
@@ -565,6 +570,7 @@ export function VisualizationStudio() {
     setPlotType(nextType);
     setSelectedExampleIndex(0);
     setRawData(nextExample.data);
+    setPcaObservationMetadata(nextExample.metadata ?? "");
     setMapping(nextExample.mapping ?? next.defaultMapping);
     setLoadedFileName("");
     setFileError("");
@@ -575,6 +581,7 @@ export function VisualizationStudio() {
       xLabel: "",
       yLabel: "",
       swapAxes: false,
+      ordinationView: (["pca", "pcoa", "umap", "tsne", "nmds"] as PlotType[]).includes(nextType) ? "scores" : current.ordinationView,
       clusterColumns: nextType === "correlation-heatmap" ? current.clusterRows : current.clusterColumns,
       heatmapColumnClusters: nextType === "correlation-heatmap" ? current.heatmapRowClusters : current.heatmapColumnClusters,
       compositionLabelMode: nextType === "rose" ? "value" : current.compositionLabelMode,
@@ -698,7 +705,7 @@ export function VisualizationStudio() {
       setRawData(text);
       setSelectedExampleIndex(-1);
       setLoadedFileName(file.name);
-      if (plotType === "pca") setMapping(definition.defaultMapping);
+      if (plotType === "pca") { setPcaObservationMetadata(""); setMapping(definition.defaultMapping); }
       else setMapping(inferPlotMapping(definition, parseDelimitedData(text).headers));
     } catch (error) {
       setFileError(error instanceof Error ? error.message : "The selected file could not be read.");
@@ -709,6 +716,12 @@ export function VisualizationStudio() {
   const downloadInputTemplate = () => {
     const example = dataExamples[selectedExampleIndex >= 0 ? selectedExampleIndex : 0] ?? dataExamples[0];
     downloadBlob(new Blob([example.data], { type: "text/tab-separated-values;charset=utf-8" }), `${slug(definition.name)}-${slug(example.label)}-template.tsv`);
+  };
+
+  const downloadPcaMetadataTemplate = () => {
+    const example = dataExamples[selectedExampleIndex >= 0 ? selectedExampleIndex : 0] ?? dataExamples[0];
+    const metadata = example.metadata ?? "sample\tgroup\tbatch\tlabel\nSample_1\tControl\tBatch 1\tS1";
+    downloadBlob(new Blob([metadata], { type: "text/tab-separated-values;charset=utf-8" }), `${slug(definition.name)}-observation-metadata-template.tsv`);
   };
 
   const exportSvg = () => {
@@ -757,9 +770,12 @@ export function VisualizationStudio() {
         detectedLayer: pcaAnalysis.detectedLayer,
         sampleColumns: pcaAnalysis.sampleColumns,
         featuresRead: pcaAnalysis.featuresRead,
+        featuresComplete: pcaAnalysis.featuresComplete,
+        featuresVariable: pcaAnalysis.featuresVariable,
         featuresUsed: pcaAnalysis.featuresUsed,
         explainedVariance: pcaAnalysis.explainedVariance,
         transformation: pcaAnalysis.transformation,
+        observationMetadata: pcaObservationMetadata,
       } : undefined,
       data: rawData,
     };
@@ -905,6 +921,7 @@ export function VisualizationStudio() {
                     <pre className="mt-3 max-h-40 overflow-hidden whitespace-pre-wrap font-mono text-[10px] leading-4 text-graphite">{rawData.slice(0, 8_000)}</pre>
                   </div>
                 ) : <textarea aria-label={plotType === "pca" ? "Feature matrix" : "CSV or TSV data"} value={rawData} onChange={(event) => { setRawData(event.target.value); setSelectedExampleIndex(-1); setLoadedFileName(""); }} spellCheck={false} className="focus-ring min-h-44 resize-y rounded-[8px] border border-hairline bg-[#FBFBF9] p-3 font-mono text-[11px] leading-5 text-ink" />}
+                {plotType === "pca" ? <div className="grid gap-1.5"><span className="flex items-center justify-between gap-2"><label htmlFor="pca-observation-metadata">Observation metadata <span className="font-normal text-muted">(optional; exact sample-ID join)</span></label><button type="button" onClick={downloadPcaMetadataTemplate} className="focus-ring rounded px-1.5 py-1 text-[11px] font-medium text-moss hover:bg-sage-surface">Metadata template</button></span><textarea id="pca-observation-metadata" aria-label="PCA observation metadata" value={pcaObservationMetadata} onChange={(event) => { setPcaObservationMetadata(event.target.value); setSelectedExampleIndex(-1); }} spellCheck={false} placeholder={'sample\tgroup\tbatch\tlabel\nSample_1\tControl\tBatch 1\tS1'} className="focus-ring min-h-28 resize-y rounded-[8px] border border-hairline bg-[#FBFBF9] p-3 font-mono text-[11px] leading-5 text-ink" /><span className="text-[11px] leading-4 text-muted">The first column must match matrix observation names after removing _count, _counts, _tpm, or _fpkm. Duplicate or missing IDs block export.</span></div> : null}
                 {fileError ? <span className="text-error">{fileError}</span> : null}
               </div>
               <div className="space-y-2.5">
@@ -917,7 +934,7 @@ export function VisualizationStudio() {
                 </div>
                 {plotType === "pca" && pcaAnalysis ? <>
                   <SelectControl label="Data layer" value={pcaOptions.dataLayer} onChange={(value) => setPcaOptions((current) => ({ ...current, dataLayer: value as PcaDataLayer }))}>
-                    <option value="auto">Auto-detect (recommended)</option>
+                    <option value="auto">Auto by explicit suffix; otherwise normalized</option>
                     <option value="counts">Count matrix → log₂(CPM + 1)</option>
                     <option value="abundance">Non-negative abundance → log₂(x + 1)</option>
                     <option value="normalized">Continuous / already normalized</option>
@@ -932,10 +949,16 @@ export function VisualizationStudio() {
                   <SelectControl label="Y component" value={mapping.y} onChange={(value) => setMapping((current) => ({ ...current, y: value }))}>
                     {dataset.headers.filter((header) => /^PC\d+$/.test(header)).map((header) => <option key={header} value={header}>{pcaAxisLabel(header, pcaAnalysis.explainedVariance)}</option>)}
                   </SelectControl>
+                  {settings.ordinationView === "3d" ? <SelectControl label="Z component" value={mapping.z} onChange={(value) => setMapping((current) => ({ ...current, z: value }))}>
+                    {dataset.headers.filter((header) => /^PC\d+$/.test(header)).map((header) => <option key={header} value={header}>{pcaAxisLabel(header, pcaAnalysis.explainedVariance)}</option>)}
+                  </SelectControl> : null}
+                  <SelectControl label="Color group" value={mapping.group} onChange={(value) => setMapping((current) => ({ ...current, group: value }))}><option value="">None</option>{dataset.headers.map((header) => <option key={header} value={header}>{header}</option>)}</SelectControl>
+                  <SelectControl label="Shape group" value={mapping.shape} onChange={(value) => setMapping((current) => ({ ...current, shape: value }))}><option value="">None</option>{dataset.headers.map((header) => <option key={header} value={header}>{header}</option>)}</SelectControl>
+                  <SelectControl label="Observation label" value={mapping.label} onChange={(value) => setMapping((current) => ({ ...current, label: value }))}><option value="">None</option>{dataset.headers.map((header) => <option key={header} value={header}>{header}</option>)}</SelectControl>
                   <div className="rounded-[8px] border border-hairline px-3 py-2 text-[11px] leading-5 text-muted">
-                    <p>{pcaAnalysis.sampleColumns.length} observations · {pcaAnalysis.featuresUsed.toLocaleString()} / {pcaAnalysis.featuresRead.toLocaleString()} features used</p>
+                    <p>{pcaAnalysis.sampleColumns.length} observations · {pcaAnalysis.featuresUsed.toLocaleString()} used / {pcaAnalysis.featuresVariable.toLocaleString()} variable / {pcaAnalysis.featuresComplete.toLocaleString()} complete / {pcaAnalysis.featuresRead.toLocaleString()} input features</p>
                     <p>{pcaAnalysis.transformation || "Waiting for a valid feature matrix."}</p>
-                    <p>{pcaAnalysis.groups.length} inferred group{pcaAnalysis.groups.length === 1 ? "" : "s"}: {pcaAnalysis.groups.join(" · ") || "—"}</p>
+                    <p>{pcaAnalysis.groups.length} displayed group{pcaAnalysis.groups.length === 1 ? "" : "s"}: {pcaAnalysis.groups.join(" · ") || "—"}{pcaObservationMetadata.trim() ? " · exact-ID metadata" : " · inferred from delimited replicate suffixes"}</p>
                     {pcaAnalysis.availableLayers.length > 1 ? <p>Detected layers: {pcaAnalysis.availableLayers.map((layer) => `${layer.label} (${layer.columns})`).join(" · ")}</p> : null}
                   </div>
                 </> : visibleRoles.length === 0 ? <p className="rounded-[8px] bg-stone px-3 py-2 text-xs leading-5 text-graphite">The first column supplies row labels; all remaining columns form the numeric matrix.</p> : visibleRoles.map((role) => (
@@ -993,9 +1016,9 @@ export function VisualizationStudio() {
               {hasSetting("opacity") ? <RangeControl label="Opacity" value={settings.opacity} minimum={0.25} maximum={1} step={0.05} onChange={(value) => updateSetting("opacity", value)} /> : null}
               {hasSetting("grid") ? <SelectControl label="Grid" value={settings.grid} onChange={(value) => updateSetting("grid", value as VisualizationSettings["grid"])}><option value="none">None</option><option value="y">Horizontal only</option><option value="both">Both axes</option></SelectControl> : null}
               {hasSetting("legendPosition") && !((plotType === "scatter" || plotType === "correlation") && ["density", "hexbin"].includes(settings.associationVariant)) ? <SelectControl label="Legend" value={settings.legendPosition} onChange={(value) => updateSetting("legendPosition", value as VisualizationSettings["legendPosition"])}><option value="right">Right</option>{plotType !== "enrichment" && plotType !== "enrichment-bar" ? <option value="bottom">Bottom</option> : null}<option value="none">Hidden</option></SelectControl> : null}
-              {(plotType === "line" || plotType === "pca" || ((plotType === "scatter" || plotType === "correlation") && !["pair-matrix", "3d", "ternary"].includes(settings.associationVariant)) || (plotType === "bar" && !["horizontal", "bullet", "pyramid", "dual-axis", "overlay", "polar", "faceted"].includes(settings.barVariant))) ? <ToggleControl label="Swap axes" checked={settings.swapAxes} onChange={(value) => updateSetting("swapAxes", value)} /> : null}
+              {(plotType === "line" || (plotType === "pca" && settings.ordinationView === "scores") || ((plotType === "scatter" || plotType === "correlation") && !["pair-matrix", "3d", "ternary"].includes(settings.associationVariant)) || (plotType === "bar" && !["horizontal", "bullet", "pyramid", "dual-axis", "overlay", "polar", "faceted"].includes(settings.barVariant))) ? <ToggleControl label="Swap axes" checked={settings.swapAxes} onChange={(value) => updateSetting("swapAxes", value)} /> : null}
               {(plotType === "scatter" || plotType === "correlation") && ["points", "marginal", "ellipse", "hull"].includes(settings.associationVariant) ? <ToggleControl label="Point labels" checked={settings.showLabels} onChange={(value) => updateSetting("showLabels", value)} /> : null}
-              {(["pca", "pcoa", "umap", "quadrant"] as PlotType[]).includes(plotType) ? <ToggleControl label="Point labels" checked={settings.showLabels} onChange={(value) => updateSetting("showLabels", value)} /> : null}
+              {(["pca", "pcoa", "umap", "tsne", "nmds", "quadrant"] as PlotType[]).includes(plotType) ? <ToggleControl label="Point labels" checked={settings.showLabels} onChange={(value) => updateSetting("showLabels", value)} /> : null}
             </ControlGroup> : null}
 
             {plotType === "line" || (plotType === "bar" && !["stacked", "percentage", "polar"].includes(settings.barVariant)) ? <ControlGroup title={`${plotType === "bar" ? "Bar" : "Line"} uncertainty`}>
@@ -1050,6 +1073,24 @@ export function VisualizationStudio() {
               <p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Pearson tests linear association; Spearman tests monotonic rank association. Reported P values use a two-sided t approximation and do not adjust for multiple testing. Confidence ribbons are mean-response intervals for linear fits, not prediction intervals. Ternary rows are normalized to proportions. The 3D view independently min–max scales X, Y, and Z before a fixed-size orthographic projection; it preserves order, not cross-axis units or perspective.</p>
             </ControlGroup> : null}
             {plotType === "correlation-heatmap" ? <ControlGroup title="Correlation"><SelectControl label="Method" value={settings.correlationMethod} onChange={(value) => updateSetting("correlationMethod", value as VisualizationSettings["correlationMethod"])}><option value="pearson">Pearson</option><option value="spearman">Spearman</option></SelectControl><p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Each matrix cell is calculated from paired complete observations. This view reports coefficients, not inferential P values.</p></ControlGroup> : null}
+            {(["pca", "pcoa", "umap", "tsne", "nmds"] as PlotType[]).includes(plotType) ? <>
+              <ControlGroup title="Ordination view">
+                <SelectControl label="View" value={settings.ordinationView} onChange={(value) => updateSetting("ordinationView", value as VisualizationSettings["ordinationView"])}><option value="scores">Scores / coordinates</option>{plotType === "pca" ? <option value="scree">Scree plot</option> : null}<option value="3d">Orthographic 3D projection</option></SelectControl>
+                {settings.ordinationView === "scores" ? <><ToggleControl label="Group covariance ellipses" checked={settings.ordinationShowEllipse} onChange={(value) => updateSetting("ordinationShowEllipse", value)} /><ToggleControl label="Group convex hulls" checked={settings.ordinationShowHull} onChange={(value) => updateSetting("ordinationShowHull", value)} /><ToggleControl label="Group centroids" checked={settings.ordinationShowCentroids} onChange={(value) => updateSetting("ordinationShowCentroids", value)} />{plotType === "pca" ? <><ToggleControl label="Feature loading arrows" checked={settings.ordinationShowLoadings} onChange={(value) => updateSetting("ordinationShowLoadings", value)} />{settings.ordinationShowLoadings ? <RangeControl label="Loading labels" value={settings.ordinationLoadingCount} minimum={1} maximum={30} step={1} onChange={(value) => updateSetting("ordinationLoadingCount", value)} /> : null}</> : null}</> : settings.ordinationView === "3d" ? <ToggleControl label="Group centroids" checked={settings.ordinationShowCentroids} onChange={(value) => updateSetting("ordinationShowCentroids", value)} /> : null}
+                {settings.ordinationView !== "scree" ? <ToggleControl label="Use mapped shapes" checked={settings.ordinationUseShapes} onChange={(value) => updateSetting("ordinationUseShapes", value)} /> : null}
+              <p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Ellipses summarize within-group covariance; hulls only enclose observed extremes. Neither is a confidence region. The 3D view independently min–max scales each axis before a fixed orthographic projection, so cross-axis distances, angles, and apparent separation are not quantitative; manual 2D limits do not apply.</p>
+              </ControlGroup>
+              {settings.ordinationView !== "scree" ? <><ControlGroup title={plotType === "pca" ? "Analysis note" : "Upstream method"}>
+                {plotType === "pcoa" ? <div className="grid grid-cols-2 gap-2"><OptionalNumberControl label="PCoA 1 variance (%)" value={settings.ordinationXVariance} onChange={(value) => updateSetting("ordinationXVariance", value)} /><OptionalNumberControl label="PCoA 2 variance (%)" value={settings.ordinationYVariance} onChange={(value) => updateSetting("ordinationYVariance", value)} /><OptionalNumberControl label="PCoA 3 variance (%)" value={settings.ordinationZVariance} onChange={(value) => updateSetting("ordinationZVariance", value)} /></div> : null}
+                {plotType === "nmds" ? <OptionalNumberControl label="Supplied stress" value={settings.ordinationStress} onChange={(value) => updateSetting("ordinationStress", value)} /> : null}
+                <TextControl label="Method note" value={settings.ordinationMethodNote} onChange={(value) => updateSetting("ordinationMethodNote", value)} placeholder={plotType === "pca" ? "PERMANOVA formula, distance, strata, and permutation scheme" : plotType === "umap" ? "seed=42; n_neighbors=15; min_dist=0.1; metric=cosine" : plotType === "tsne" ? "seed=42; perplexity=30; iterations=1000" : plotType === "nmds" ? "Bray–Curtis; k=2; 50 starts; converged" : "Bray–Curtis distance; correction=none"} />
+              </ControlGroup>
+              <ControlGroup title="Supplied PERMANOVA">
+                <div className="grid grid-cols-2 gap-2"><OptionalNumberControl label="R²" value={settings.ordinationPermanovaR2} onChange={(value) => updateSetting("ordinationPermanovaR2", value)} /><OptionalNumberControl label="P value" value={settings.ordinationPermanovaP} onChange={(value) => updateSetting("ordinationPermanovaP", value)} /><OptionalNumberControl label="Permutations" value={settings.ordinationPermanovaPermutations} onChange={(value) => updateSetting("ordinationPermanovaPermutations", value)} /></div>
+                <p className="text-[11px] leading-4 text-muted">These values are displayed exactly as supplied and are never inferred from the plotted coordinates. Report the upstream distance, grouping formula, strata/blocking, and permutation scheme in the method note.</p>
+              </ControlGroup>
+              </> : null}
+            </> : null}
             {plotType === "quadrant" ? <ControlGroup title="Quadrant thresholds"><RangeControl label="X threshold" value={settings.xThreshold} minimum={-10} maximum={10} step={0.1} onChange={(value) => updateSetting("xThreshold", value)} /><RangeControl label="Y threshold" value={settings.yThreshold} minimum={-10} maximum={10} step={0.1} onChange={(value) => updateSetting("yThreshold", value)} /></ControlGroup> : null}
             {plotType === "errorbar" ? <ControlGroup title="Error bars"><RangeControl label="Error line" value={settings.errorBarLineWidth} minimum={0.8} maximum={3} step={0.1} unit=" px" onChange={(value) => updateSetting("errorBarLineWidth", value)} /><RangeControl label="Cap width" value={settings.errorBarCapSize} minimum={4} maximum={30} step={1} unit=" px" onChange={(value) => updateSetting("errorBarCapSize", value)} /><p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">The mapped error column must already contain SD or SEM. Record which statistic you used in the title, axis, caption, or exported config.</p></ControlGroup> : null}
             {(["heatmap", "clustered-heatmap", "correlation-heatmap"] as PlotType[]).includes(plotType) ? <>

--- a/src/lib/plot-module-registry.test.ts
+++ b/src/lib/plot-module-registry.test.ts
@@ -77,7 +77,7 @@ describe("plot-module registry interface", () => {
   });
 
   it("adapts all existing plots to the shared module contract", () => {
-    expect(plotModuleRegistry.list()).toHaveLength(43);
+    expect(plotModuleRegistry.list()).toHaveLength(45);
     plotModuleRegistry.list().forEach((plotModule) => {
       expect(plotModule.definition.id).toBeTruthy();
       expect(plotModule.examples.length).toBeGreaterThan(0);
@@ -95,6 +95,10 @@ describe("plot-module registry interface", () => {
     expect(getPlotModule("scatter").capabilities.settingKeys).toEqual(expect.arrayContaining(["associationVariant", "associationFit", "associationShowConfidenceBand", "associationShowPValue", "associationGroupMode"]));
     expect(getPlotModule("correlation").capabilities.settingKeys).toEqual(expect.arrayContaining(["correlationMethod", "associationVariant", "associationFit"]));
     expect(getPlotModule("pca").capabilities.settingKeys).toContain("swapAxes");
+    expect(getPlotModule("pca").renderer).toBe("advanced");
+    expect(getPlotModule("pca").capabilities.settingKeys).toEqual(expect.arrayContaining(["ordinationView", "ordinationShowLoadings", "ordinationPermanovaR2"]));
+    expect(getPlotModule("tsne").capabilities.dataShape).toBe("coordinates");
+    expect(getPlotModule("nmds").capabilities.settingKeys).toContain("ordinationStress");
     expect(getPlotModule("box").capabilities.settingKeys).not.toContain("legendPosition");
     expect(getPlotModule("circos").renderer).toBe("advanced");
     expect(getPlotModule("pie").capabilities.settingKeys).not.toContain("xLabel");

--- a/src/lib/plot-module-registry.ts
+++ b/src/lib/plot-module-registry.ts
@@ -3,7 +3,7 @@ export type PlotRendererId = "standard" | "advanced";
 export type PlotDataShape = "long" | "matrix" | "coordinates" | "sets" | "network" | "hierarchy" | "genomic-links";
 
 type PlotRoleLike = { key: string; label: string; kind: "category" | "number" | "label"; required: boolean };
-type PlotExampleLike = { label: string; description: string; data: string; mapping?: Record<string, string> };
+type PlotExampleLike = { label: string; description: string; data: string; metadata?: string; mapping?: Record<string, string> };
 type PlotDefinitionLike<PlotId extends string> = {
   id: PlotId;
   name: string;

--- a/src/lib/plot-module-rendering.test.tsx
+++ b/src/lib/plot-module-rendering.test.tsx
@@ -13,7 +13,7 @@ import {
 } from "./visualization-studio";
 
 const expectedAdvancedRenderers = new Set([
-  "line", "scatter", "correlation", "pcoa", "umap", "box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "ma", "quadrant", "errorbar", "area", "lollipop",
+  "line", "scatter", "correlation", "pca", "pcoa", "umap", "tsne", "nmds", "box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "ma", "quadrant", "errorbar", "area", "lollipop",
   "heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment-bar", "gsea", "km", "survival-forest", "roc", "venn",
   "upset", "sankey", "chord", "circos",
   "pie", "donut", "rose", "waffle", "treemap", "sunburst", "radar", "polar-profile", "population-pyramid",
@@ -23,7 +23,7 @@ describe("registered plot-module examples", () => {
   it("parses, maps, validates, and renders every bundled example with finite SVG geometry", () => {
     for (const plotModule of plotModuleRegistry.list()) {
       for (const example of plotModule.examples) {
-        const analysis = plotModule.definition.id === "pca" ? analyzeExpressionMatrix(example.data) : null;
+        const analysis = plotModule.definition.id === "pca" ? analyzeExpressionMatrix(example.data, undefined, example.metadata ?? "") : null;
         const dataset = analysis?.dataset ?? parseDelimitedData(example.data);
         const inferredMapping = analysis ? plotModule.definition.defaultMapping : inferPlotMapping(plotModule.definition, dataset.headers);
         const selectedMapping = example.mapping ?? inferredMapping;
@@ -96,6 +96,70 @@ describe("registered plot-module examples", () => {
       }
       expect(markup, associationVariant).not.toMatch(/(?:NaN|Infinity|-Infinity|undefined)/);
     }
+  });
+
+  it("renders ordination overlays, supplied statistics, scree, loadings, shapes, and 3D views", () => {
+    const pcaModule = plotModuleRegistry.get("pca");
+    const pca = analyzeExpressionMatrix(pcaModule.examples[0].data, undefined, pcaModule.examples[0].metadata ?? "");
+    expect(pca.dataset.errors).toEqual([]);
+    const pcaMapping = pcaModule.examples[0].mapping ?? pcaModule.definition.defaultMapping;
+    const scoreSettings = { ...defaultVisualizationSettings, ordinationShowEllipse: true, ordinationShowHull: true, ordinationShowCentroids: true, ordinationShowLoadings: true, ordinationUseShapes: true };
+    expect(validatePlotDataset(pcaModule.definition, pca.dataset, pcaMapping, scoreSettings).errors).toEqual([]);
+    const scoreMarkup = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="pca" dataset={pca.dataset} mapping={pcaMapping} settings={scoreSettings} themeId={defaultVisualizationThemeId} />);
+    for (const element of ["ordination-ellipse", "ordination-hull", "ordination-centroid", "ordination-loading", "ordination-point"]) expect(scoreMarkup).toContain(`data-plot-element="${element}"`);
+    expect(scoreMarkup).toContain('data-plot-element="ordination-shape-legend"');
+    expect(scoreMarkup).toMatch(/PC1 \([\d.]+%\)/);
+    expect(scoreMarkup).not.toMatch(/(?:NaN|Infinity|-Infinity|undefined)/);
+    const swappedMarkup = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="pca" dataset={pca.dataset} mapping={pcaMapping} settings={{ ...defaultVisualizationSettings, swapAxes: true, ordinationShowLoadings: true }} themeId={defaultVisualizationThemeId} />);
+    expect(swappedMarkup).toMatch(/PC2 \([\d.]+%\)/);
+    expect(swappedMarkup).toContain('data-plot-element="ordination-loading"');
+
+    const screeSettings = { ...defaultVisualizationSettings, ordinationView: "scree" as const };
+    expect(validatePlotDataset(pcaModule.definition, pca.dataset, {}, screeSettings).errors).toEqual([]);
+    const screeMarkup = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="pca" dataset={pca.dataset} mapping={{}} settings={screeSettings} themeId={defaultVisualizationThemeId} />);
+    expect(screeMarkup).toContain('data-plot-family="ordination-scree"');
+    expect(screeMarkup).toContain('data-plot-element="scree-bar"');
+    const pca3dSettings = { ...defaultVisualizationSettings, ordinationView: "3d" as const, ordinationShowCentroids: true };
+    expect(validatePlotDataset(pcaModule.definition, pca.dataset, pcaMapping, pca3dSettings).errors).toEqual([]);
+    const pca3dMarkup = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="pca" dataset={pca.dataset} mapping={pcaMapping} settings={pca3dSettings} themeId={defaultVisualizationThemeId} />);
+    expect(pca3dMarkup).toContain('data-plot-family="ordination-3d"');
+    expect(pca3dMarkup).toContain('data-plot-element="ordination-shape-legend"');
+    expect(pca3dMarkup).toContain("PC3 (");
+    expect(pca3dMarkup).not.toMatch(/(?:NaN|Infinity|-Infinity|undefined)/);
+
+    const pcoaModule = plotModuleRegistry.get("pcoa");
+    const pcoaData = parseDelimitedData(pcoaModule.definition.sampleData);
+    const suppliedSettings = { ...defaultVisualizationSettings, ordinationView: "3d" as const, ordinationShowCentroids: true, ordinationXVariance: 41.2, ordinationYVariance: 22.4, ordinationZVariance: 11.3, ordinationPermanovaR2: 0.183, ordinationPermanovaP: 0.004, ordinationPermanovaPermutations: 999, ordinationMethodNote: "Bray-Curtis; blocked permutations by cohort" };
+    expect(validatePlotDataset(pcoaModule.definition, pcoaData, pcoaModule.definition.defaultMapping, suppliedSettings).errors).toEqual([]);
+    const pcoaMarkup = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="pcoa" dataset={pcoaData} mapping={pcoaModule.definition.defaultMapping} settings={suppliedSettings} themeId={defaultVisualizationThemeId} />);
+    expect(pcoaMarkup).toContain('data-plot-family="ordination-3d"');
+    expect(pcoaMarkup).toContain("PERMANOVA (supplied)");
+    expect(pcoaMarkup).toContain("PCoA 3 (11.3%)");
+    expect(pcoaMarkup).not.toMatch(/(?:NaN|Infinity|-Infinity|undefined)/);
+
+    const swappedPcoaMarkup = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="pcoa" dataset={pcoaData} mapping={{ ...pcoaModule.definition.defaultMapping, x: "dim2", y: "dim1" }} settings={{ ...defaultVisualizationSettings, ordinationXVariance: 41.2, ordinationYVariance: 22.4 }} themeId={defaultVisualizationThemeId} />);
+    expect(swappedPcoaMarkup).toContain("PCoA 2 (22.4%)");
+    expect(swappedPcoaMarkup).toContain("PCoA 1 (41.2%)");
+    const explicitSuffixData = parseDelimitedData("cohort2024_axis1\tcohort2024_axis2\tgroup\tsample\n0\t1\tA\tLeftBoundaryLabel\n1\t0\tB\tRightBoundaryLabel");
+    const suffixMarkup = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="pcoa" dataset={explicitSuffixData} mapping={{ x: "cohort2024_axis1", y: "cohort2024_axis2", group: "group", label: "sample" }} settings={{ ...defaultVisualizationSettings, showLabels: true, ordinationXVariance: 60, ordinationYVariance: 40 }} themeId={defaultVisualizationThemeId} />);
+    expect(suffixMarkup).toContain("PCoA 1 (60.0%)");
+    expect(suffixMarkup).toContain("PCoA 2 (40.0%)");
+    expect(suffixMarkup).not.toContain("PCoA 2024");
+    expect(suffixMarkup).toContain('data-full-label="RightBoundaryLabel"');
+    expect(suffixMarkup).toMatch(/data-plot-label[^>]*text-anchor="middle"[^>]*>.*RightBou…/);
+  });
+
+  it("blocks overflowing ordination legends and keeps hidden-legend colors distinct", () => {
+    const pcoaModule = plotModuleRegistry.get("pcoa");
+    const rows = Array.from({ length: 13 }, (_, index) => `${index}\t${index % 4}\t${index % 3}\tGroup ${index + 1}\tS${index + 1}`).join("\n");
+    const dataset = parseDelimitedData(`dim1\tdim2\tdim3\tgroup\tsample\n${rows}`);
+    const mapping = { ...pcoaModule.definition.defaultMapping, shape: "" };
+    expect(validatePlotDataset(pcoaModule.definition, dataset, mapping, defaultVisualizationSettings).errors.join(" ")).toMatch(/at most 12/);
+    const hiddenLegendSettings = { ...defaultVisualizationSettings, legendPosition: "none" as const };
+    expect(validatePlotDataset(pcoaModule.definition, dataset, mapping, hiddenLegendSettings).errors).toEqual([]);
+    const markup = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type="pcoa" dataset={dataset} mapping={mapping} settings={hiddenLegendSettings} themeId={defaultVisualizationThemeId} />);
+    const pointColors = [...markup.matchAll(/data-plot-element="ordination-point"[^>]*fill="([^"]+)"/g)].map((match) => match[1]);
+    expect(new Set(pointColors).size).toBe(13);
   });
 
   it("keeps dense correlation summaries inside the reclaimed compact canvas", () => {

--- a/src/lib/visualization-pca.test.ts
+++ b/src/lib/visualization-pca.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { analyzeExpressionMatrix, inferPcaGroup } from "./visualization-pca";
+import { analyzeExpressionMatrix, inferPcaGroup, nipalsPca } from "./visualization-pca";
 
 const mixedExpressionTable = `gene_id\tC1_count\tC2_count\tC3_count\tT1_count\tT2_count\tT3_count\tC1_fpkm\tC2_fpkm\tC3_fpkm\tT1_fpkm\tT2_fpkm\tT3_fpkm\tTvsC_log2FoldChange\tTvsC_padj\tgene_length\tgene_name
 g1\t100\t110\t105\t420\t440\t410\t2.1\t2.2\t2.0\t8.4\t8.8\t8.2\t2.0\t0.001\t1200\tGene1
@@ -10,16 +10,19 @@ g5\t45\t50\t48\t160\t170\t155\t0.9\t1.0\t0.96\t3.2\t3.4\t3.1\t1.8\t0.002\t700\tG
 g6\t720\t700\t735\t400\t420\t390\t14.4\t14.0\t14.7\t8.0\t8.4\t7.8\t-0.9\t0.03\t1100\tGene6`;
 
 describe("Visualization Studio PCA", () => {
-  it("prefers raw-count sample columns in a mixed RNA-seq results table", () => {
+  it("prefers explicitly suffixed raw-count columns in a mixed results table", () => {
     const result = analyzeExpressionMatrix(mixedExpressionTable, { dataLayer: "auto", topVariableFeatures: 2_000, scaleFeatures: false });
     expect(result.dataset.errors).toEqual([]);
     expect(result.detectedLayer).toBe("counts");
     expect(result.sampleColumns).toEqual(["C1_count", "C2_count", "C3_count", "T1_count", "T2_count", "T3_count"]);
     expect(result.sampleNames).toEqual(["C1", "C2", "C3", "T1", "T2", "T3"]);
-    expect(result.groups).toEqual(["C", "T"]);
+    expect(result.groups).toEqual(["C1", "C2", "C3", "T1", "T2", "T3"]);
     expect(result.dataset.rows).toHaveLength(6);
     expect(result.explainedVariance.slice(0, 2).every((value) => value > 0)).toBe(true);
     expect(result.explainedVariance.reduce((sum, value) => sum + value, 0)).toBeCloseTo(1, 8);
+    expect(result.loadings).toHaveLength(6);
+    expect(result.loadings.every((loading) => loading.feature && loading.coordinates.length >= 2 && loading.coordinates.every(Number.isFinite))).toBe(true);
+    expect(result.dataset.analysis?.pca?.loadings).toEqual(result.loadings);
     expect(result.transformation).toContain("log₂(CPM + 1)");
   });
 
@@ -31,17 +34,125 @@ describe("Visualization Studio PCA", () => {
     expect(result.transformation).toBe("log₂(non-negative abundance + 1)");
   });
 
-  it("excludes numeric gene annotations from a plain count matrix", () => {
-    const raw = `gene_id\tA1\tA2\tA3\tgene_start\tgene_end\tgene_length\nG1\t10\t12\t11\t100\t200\t101\nG2\t40\t42\t38\t300\t500\t201\nG3\t80\t75\t85\t600\t800\t201\nG4\t20\t18\t22\t900\t950\t51`;
-    const result = analyzeExpressionMatrix(raw, { dataLayer: "auto", topVariableFeatures: 500, scaleFeatures: false });
+  it("does not guess counts from unsigned integer values without an explicit suffix", () => {
+    const raw = `gene_id\tA1\tA2\tA3\tgene_start\tgene_end\tgene_length
+G1\t10\t12\t11\t100\t200\t101
+G2\t40\t42\t38\t300\t500\t201
+G3\t80\t75\t85\t600\t800\t201
+G4\t20\t18\t22\t900\t950\t51`;
+    const automatic = analyzeExpressionMatrix(raw, { dataLayer: "auto", topVariableFeatures: 500, scaleFeatures: false });
+    expect(automatic.dataset.errors).toEqual([]);
+    expect(automatic.sampleColumns).toEqual(["A1", "A2", "A3"]);
+    expect(automatic.detectedLayer).toBe("normalized");
+    expect(automatic.transformation).toBe("No log transformation");
+
+    const explicitCounts = analyzeExpressionMatrix(raw, { dataLayer: "counts", topVariableFeatures: 500, scaleFeatures: false });
+    expect(explicitCounts.dataset.errors).toEqual([]);
+    expect(explicitCounts.detectedLayer).toBe("counts");
+    expect(explicitCounts.transformation).toContain("log₂(CPM + 1)");
+  });
+
+  it("treats unsigned decimal matrices as normalized unless abundance is explicit", () => {
+    const raw = "feature\tS1\tS2\tS3\nA\t1.2\t1.8\t2.5\nB\t4.3\t3.1\t2.2\nC\t0.4\t1.0\t1.6";
+    expect(analyzeExpressionMatrix(raw).detectedLayer).toBe("normalized");
+    expect(analyzeExpressionMatrix(raw, { dataLayer: "abundance", topVariableFeatures: 2_000, scaleFeatures: false }).detectedLayer).toBe("abundance");
+  });
+
+  it("joins independent observation metadata by exact sample ID", () => {
+    const metadata = `sample\tgroup\tbatch\tlabel
+C1\tVehicle\tB1\tControl one
+C2\tVehicle\tB2\tControl two
+C3\tVehicle\tB1\tControl three
+T1\tDrug\tB2\tTreatment one
+T2\tDrug\tB1\tTreatment two
+T3\tDrug\tB2\tTreatment three`;
+    const result = analyzeExpressionMatrix(mixedExpressionTable, undefined, metadata);
     expect(result.dataset.errors).toEqual([]);
-    expect(result.sampleColumns).toEqual(["A1", "A2", "A3"]);
-    expect(result.detectedLayer).toBe("counts");
+    expect(result.groups).toEqual(["Vehicle", "Drug"]);
+    expect(result.dataset.headers).toEqual(expect.arrayContaining(["group", "batch", "label", "PC1", "PC2"]));
+    expect(result.dataset.rows[0]).toMatchObject({ sample: "C1", group: "Vehicle", batch: "B1", label: "Control one" });
+
+    const invalid = analyzeExpressionMatrix(mixedExpressionTable, undefined, metadata.replace("T3\tDrug\tB2\tTreatment three", "C1\tDrug\tB2\tDuplicate"));
+    expect(invalid.dataset.errors.join(" ")).toMatch(/duplicate: C1/i);
+    expect(invalid.dataset.errors.join(" ")).toMatch(/missing 1 sample ID: T3/i);
+  });
+
+  it("matches a small reference PCA spectrum and keeps every selected loading", () => {
+    const reference = `feature_id\tS1\tS2\tS3\tS4
+A\t0\t2\t4\t6
+B\t0\t2\t2\t0`;
+    const result = analyzeExpressionMatrix(reference, { dataLayer: "normalized", topVariableFeatures: 100, scaleFeatures: false });
+    expect(result.dataset.errors).toEqual([]);
+    expect(result.explainedVariance[0]).toBeCloseTo(5 / 6, 6);
+    expect(result.explainedVariance[1]).toBeCloseTo(1 / 6, 6);
+    expect(result.loadings).toHaveLength(2);
+    expect(result.loadings.every((loading) => loading.coordinates.length === 2)).toBe(true);
+  });
+
+  it("retains feature loadings for higher selected components instead of prefiltering by PC1-PC3", () => {
+    const headers = Array.from({ length: 8 }, (_, index) => `S${index + 1}`);
+    const rows = Array.from({ length: 60 }, (_, featureIndex) => {
+      const values = headers.map((_, sampleIndex) => Math.cos(Math.PI * (sampleIndex + 0.5) * (featureIndex + 1) / 8) * (1 + featureIndex / 20));
+      return `Feature_${featureIndex + 1}\t${values.join("\t")}`;
+    });
+    const result = analyzeExpressionMatrix(`feature\t${headers.join("\t")}\n${rows.join("\n")}`, { dataLayer: "normalized", topVariableFeatures: 100, scaleFeatures: false });
+    expect(result.dataset.errors).toEqual([]);
+    expect(result.loadings).toHaveLength(result.featuresUsed);
+    expect(result.loadings.length).toBeGreaterThan(50);
+    expect(result.loadings.every((loading) => Number.isFinite(loading.coordinates[3]))).toBe(true);
+  });
+
+  it("caps browser PCA at 300 observations and counts malformed input rows in provenance", () => {
+    const sampleHeaders = Array.from({ length: 301 }, (_, index) => `S${index + 1}`).join("\t");
+    const oversized = `feature\t${sampleHeaders}\nA\t${Array.from({ length: 301 }, (_, index) => index).join("\t")}\nB\t${Array.from({ length: 301 }, (_, index) => index % 7).join("\t")}`;
+    expect(analyzeExpressionMatrix(oversized).dataset.errors.join(" ")).toMatch(/limited to 300 observations/);
+
+    const incomplete = "feature\tS1\tS2\tS3\nA\t1\t2\t3\nmalformed\t1\t2\nB\t4\tbad\t6\nC\t2\t4\t7\nD\t3\t7\t8";
+    const result = analyzeExpressionMatrix(incomplete, { dataLayer: "normalized", topVariableFeatures: 100, scaleFeatures: false });
+    expect(result.featuresRead).toBe(5);
+    expect(result.featuresComplete).toBe(3);
+    expect(result.dataset.warnings.join(" ")).toMatch(/malformed feature row/);
+    expect(result.dataset.warnings.join(" ")).toMatch(/incomplete/);
+  });
+
+  it("treats blank cells as incomplete and requires unique feature IDs", () => {
+    const blank = "feature\tS1\tS2\tS3\nA\t1\t\t3\nB\t2\t4\t6\nC\t3\t5\t8\nD\t4\t7\t9";
+    const blankResult = analyzeExpressionMatrix(blank, { dataLayer: "normalized", topVariableFeatures: 100, scaleFeatures: false });
+    expect(blankResult.featuresComplete).toBe(3);
+    expect(blankResult.dataset.warnings.join(" ")).toMatch(/incomplete/);
+
+    const duplicate = "feature\tS1\tS2\tS3\nA\t1\t2\t3\nA\t2\t3\t5\nB\t3\t5\t8";
+    expect(analyzeExpressionMatrix(duplicate).dataset.errors.join(" ")).toMatch(/Feature IDs must be unique.*A/);
+    const blankId = "feature\tS1\tS2\tS3\nA\t1\t2\t3\n\t2\t3\t5\nB\t3\t5\t8";
+    expect(analyzeExpressionMatrix(blankId).dataset.errors.join(" ")).toMatch(/Feature IDs must not be blank.*3/);
+  });
+
+  it("supports the 300-observation boundary and enforces the one-million-cell boundary", () => {
+    const observationHeaders = Array.from({ length: 300 }, (_, index) => `S${index + 1}`);
+    const boundaryMatrix = `feature\t${observationHeaders.join("\t")}\nA\t${observationHeaders.map((_, index) => Math.sin(index / 7)).join("\t")}\nB\t${observationHeaders.map((_, index) => Math.cos(index / 11)).join("\t")}\nC\t${observationHeaders.map((_, index) => index % 5).join("\t")}`;
+    expect(analyzeExpressionMatrix(boundaryMatrix, { dataLayer: "normalized", topVariableFeatures: 100, scaleFeatures: false }).dataset.errors).toEqual([]);
+
+    const compactHeaders = Array.from({ length: 100 }, (_, index) => `O${index + 1}`);
+    const makeRows = (count: number) => Array.from({ length: count }, (_, featureIndex) => `F${featureIndex + 1}\t${compactHeaders.map((_, sampleIndex) => ((featureIndex % 2 === 0 ? sampleIndex % 2 : sampleIndex % 4 < 2) ? 1 : -1) * (1 + featureIndex / count)).join("\t")}`).join("\n");
+    const atLimit = analyzeExpressionMatrix(`feature\t${compactHeaders.join("\t")}\n${makeRows(10_000)}`, { dataLayer: "normalized", topVariableFeatures: 0, scaleFeatures: false });
+    expect(atLimit.dataset.errors).toEqual([]);
+    const overLimit = analyzeExpressionMatrix(`feature\t${compactHeaders.join("\t")}\n${makeRows(10_001)}`, { dataLayer: "normalized", topVariableFeatures: 0, scaleFeatures: false });
+    expect(overLimit.dataset.errors.join(" ")).toMatch(/limited to one million/);
+  });
+
+  it("keeps NIPALS large-feature norms bounded and exposes non-convergence", () => {
+    const wideFeatureMatrix = Array.from({ length: 120_000 }, (_, index) => index % 2 === 0 ? [1, -1, 0] : [1, 1, -2]);
+    const result = nipalsPca(wideFeatureMatrix, 2, 2);
+    expect(result.converged).toBe(true);
+    expect(result.components).toHaveLength(2);
+    expect(nipalsPca([[1, -1, 0], [1, 1, -2]], 2, 2, 0).converged).toBe(false);
   });
 
   it("infers replicate groups without collapsing biological names", () => {
     expect(inferPcaGroup("H151_4")).toBe("H151");
     expect(inferPcaGroup("F_Pep_H151_2")).toBe("F_Pep_H151");
     expect(inferPcaGroup("Control-3")).toBe("Control");
+    expect(inferPcaGroup("H151")).toBe("H151");
+    expect(inferPcaGroup("H1650")).toBe("H1650");
   });
 });

--- a/src/lib/visualization-pca.ts
+++ b/src/lib/visualization-pca.ts
@@ -16,8 +16,11 @@ export type PcaAnalysisResult = {
   groups: string[];
   availableLayers: Array<{ id: "counts" | "abundance"; label: string; columns: number }>;
   featuresRead: number;
+  featuresComplete: number;
+  featuresVariable: number;
   featuresUsed: number;
   explainedVariance: number[];
+  loadings: Array<{ feature: string; coordinates: number[] }>;
   transformation: string;
 };
 
@@ -68,8 +71,11 @@ function emptyResult(errors: string[], delimiter: "tab" | "comma" = "tab"): PcaA
     groups: [],
     availableLayers: [],
     featuresRead: 0,
+    featuresComplete: 0,
+    featuresVariable: 0,
     featuresUsed: 0,
     explainedVariance: [],
+    loadings: [],
     transformation: "",
   };
 }
@@ -91,7 +97,7 @@ function numericCandidateColumns(headers: string[], previewRows: string[][]) {
       observed += 1;
       if (Number.isFinite(Number(rawValue))) numeric += 1;
     }
-    return observed > 0 && numeric / observed >= 0.95;
+    return observed > 0 && numeric / observed >= 0.8;
   });
 }
 
@@ -100,7 +106,7 @@ function sampleNameFromColumn(column: string) {
 }
 
 export function inferPcaGroup(sampleName: string) {
-  const withoutReplicate = sampleName.replace(/(?:[_ .-]?\d+)$/u, "").replace(/[_ .-]+$/u, "");
+  const withoutReplicate = sampleName.replace(/(?:[_ .-]\d+)$/u, "").replace(/[_ .-]+$/u, "");
   return withoutReplicate || sampleName;
 }
 
@@ -110,71 +116,56 @@ function variance(values: number[]) {
   return values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / (values.length - 1);
 }
 
-function identity(size: number): number[][] {
-  return Array.from({ length: size }, (_, row): number[] => Array.from({ length: size }, (_, column): number => row === column ? 1 : 0));
+function vectorNorm(values: number[]) {
+  return Math.sqrt(values.reduce((sum, value) => sum + value * value, 0));
 }
 
-function symmetricEigenDecomposition(input: number[][]) {
-  const size = input.length;
-  const matrix = input.map((row) => [...row]);
-  const vectors = identity(size);
-  const maximumIterations = Math.max(80, size * size * 40);
-
-  for (let iteration = 0; iteration < maximumIterations; iteration += 1) {
-    let p = 0;
-    let q = 1;
-    let maximum = 0;
-    for (let row = 0; row < size; row += 1) {
-      for (let column = row + 1; column < size; column += 1) {
-        const magnitude = Math.abs(matrix[row][column]);
-        if (magnitude > maximum) {
-          maximum = magnitude;
-          p = row;
-          q = column;
-        }
-      }
+export function nipalsPca(matrix: number[][], maximumComponents: number, denominator: number, maximumIterations = 200) {
+  const residual = matrix.map((row) => [...row]);
+  const featureCount = residual.length;
+  const sampleCount = residual[0]?.length ?? 0;
+  const components: Array<{ value: number; scores: number[]; loadings: number[] }> = [];
+  let converged = true;
+  for (let componentIndex = 0; componentIndex < Math.min(maximumComponents, featureCount, Math.max(0, sampleCount - 1)); componentIndex += 1) {
+    const initialRow = residual.reduce((best, row) => row.reduce((sum, value) => sum + value * value, 0) > best.reduce((sum, value) => sum + value * value, 0) ? row : best, residual[0]);
+    let scores = [...initialRow];
+    if (vectorNorm(scores) <= 1e-12) break;
+    let loadings = Array(featureCount).fill(0) as number[];
+    let componentConverged = false;
+    for (let iteration = 0; iteration < maximumIterations; iteration += 1) {
+      const scoreNormSquared = scores.reduce((sum, value) => sum + value * value, 0);
+      if (scoreNormSquared <= 1e-24) break;
+      loadings = residual.map((row) => row.reduce((sum, value, sampleIndex) => sum + value * scores[sampleIndex], 0) / scoreNormSquared);
+      const loadingNorm = vectorNorm(loadings);
+      if (loadingNorm <= 1e-12) break;
+      loadings = loadings.map((value) => value / loadingNorm);
+      const nextScores = Array.from({ length: sampleCount }, (_, sampleIndex) => residual.reduce((sum, row, featureIndex) => sum + row[sampleIndex] * loadings[featureIndex], 0));
+      const nextNorm = vectorNorm(nextScores);
+      const directDifference = Math.sqrt(nextScores.reduce((sum, value, index) => sum + (value - scores[index]) ** 2, 0));
+      const flippedDifference = Math.sqrt(nextScores.reduce((sum, value, index) => sum + (value + scores[index]) ** 2, 0));
+      scores = nextScores;
+      if (Math.min(directDifference, flippedDifference) <= 1e-10 * Math.max(1, nextNorm)) { componentConverged = true; break; }
     }
-    if (maximum < 1e-10) break;
-
-    const angle = 0.5 * Math.atan2(2 * matrix[p][q], matrix[q][q] - matrix[p][p]);
-    const cosine = Math.cos(angle);
-    const sine = Math.sin(angle);
-    const app = matrix[p][p];
-    const aqq = matrix[q][q];
-    const apq = matrix[p][q];
-
-    matrix[p][p] = cosine * cosine * app - 2 * sine * cosine * apq + sine * sine * aqq;
-    matrix[q][q] = sine * sine * app + 2 * sine * cosine * apq + cosine * cosine * aqq;
-    matrix[p][q] = 0;
-    matrix[q][p] = 0;
-
-    for (let index = 0; index < size; index += 1) {
-      if (index !== p && index !== q) {
-        const aip = matrix[index][p];
-        const aiq = matrix[index][q];
-        matrix[index][p] = cosine * aip - sine * aiq;
-        matrix[p][index] = matrix[index][p];
-        matrix[index][q] = sine * aip + cosine * aiq;
-        matrix[q][index] = matrix[index][q];
-      }
-      const vip = vectors[index][p];
-      const viq = vectors[index][q];
-      vectors[index][p] = cosine * vip - sine * viq;
-      vectors[index][q] = sine * vip + cosine * viq;
+    const scoreNormSquared = scores.reduce((sum, value) => sum + value * value, 0);
+    const value = scoreNormSquared / denominator;
+    if (value <= 1e-12) break;
+    if (!componentConverged) { converged = false; break; }
+    const anchor = scores.reduce((best, score) => Math.abs(score) > Math.abs(best) ? score : best, 0);
+    if (anchor < 0) {
+      scores = scores.map((score) => -score);
+      loadings = loadings.map((loading) => -loading);
     }
+    components.push({ value, scores, loadings });
+    residual.forEach((row, featureIndex) => row.forEach((entry, sampleIndex) => { row[sampleIndex] = entry - loadings[featureIndex] * scores[sampleIndex]; }));
   }
-
-  return Array.from({ length: size }, (_, index) => ({
-    value: Math.max(0, matrix[index][index]),
-    vector: vectors.map((row) => row[index]),
-  })).sort((left, right) => right.value - left.value);
+  return { components, converged };
 }
 
 function formatScore(value: number) {
   return Number.isFinite(value) ? value.toPrecision(8) : "0";
 }
 
-export function analyzeExpressionMatrix(raw: string, options: PcaOptions = defaultPcaOptions): PcaAnalysisResult {
+export function analyzeExpressionMatrix(raw: string, options: PcaOptions = defaultPcaOptions, observationMetadataRaw = ""): PcaAnalysisResult {
   const lines = normalizeLines(raw);
   if (lines.length < 2) return emptyResult(["Upload or paste a feature-by-observation matrix."]);
 
@@ -203,9 +194,20 @@ export function analyzeExpressionMatrix(raw: string, options: PcaOptions = defau
   if (selectedColumns.length < 3) {
     return { ...emptyResult(["Could not identify at least three numeric observation columns. Choose a data layer or remove annotation-only columns."], delimiterName), availableLayers };
   }
+  if (selectedColumns.length > 300) {
+    return { ...emptyResult([`Browser PCA is limited to 300 observations; detected ${selectedColumns.length}. Compute PCA in a documented external workflow and import the coordinates instead.`], delimiterName), availableLayers };
+  }
+  const sampleNames = selectedColumns.map(sampleNameFromColumn);
+  const duplicateSampleNames = [...new Set(sampleNames.filter((sample, index) => sampleNames.indexOf(sample) !== index))];
+  if (duplicateSampleNames.length > 0) {
+    return { ...emptyResult([`Observation names must remain unique after removing data-layer suffixes; duplicates: ${duplicateSampleNames.slice(0, 6).join(", ")}.`], delimiterName), availableLayers };
+  }
 
   const columnIndexes = selectedColumns.map((column) => headers.indexOf(column));
-  const rawFeatures: number[][] = [];
+  const rawFeatures: Array<{ feature: string; values: number[] }> = [];
+  const seenFeatureIds = new Set<string>();
+  const duplicateFeatureIds = new Set<string>();
+  const blankFeatureRows: number[] = [];
   let malformedRows = 0;
   let incompleteRows = 0;
   for (const line of lines.slice(1)) {
@@ -214,58 +216,78 @@ export function analyzeExpressionMatrix(raw: string, options: PcaOptions = defau
       malformedRows += 1;
       continue;
     }
-    const values = columnIndexes.map((index) => Number(cells[index]));
+    const selectedCells = columnIndexes.map((index) => cells[index]);
+    if (selectedCells.some((value) => value === undefined || value.trim() === "")) {
+      incompleteRows += 1;
+      continue;
+    }
+    const values = selectedCells.map((value) => Number(value));
     if (values.some((value) => !Number.isFinite(value))) {
       incompleteRows += 1;
       continue;
     }
-    rawFeatures.push(values);
+    const feature = cells[0]?.trim();
+    if (!feature) {
+      blankFeatureRows.push(rawFeatures.length + malformedRows + incompleteRows + blankFeatureRows.length + 2);
+      continue;
+    }
+    if (seenFeatureIds.has(feature)) duplicateFeatureIds.add(feature);
+    seenFeatureIds.add(feature);
+    rawFeatures.push({ feature, values });
+  }
+
+  if (blankFeatureRows.length > 0) {
+    return { ...emptyResult([`Feature IDs must not be blank; affected input row${blankFeatureRows.length === 1 ? "" : "s"}: ${blankFeatureRows.slice(0, 6).join(", ")}.`], delimiterName), availableLayers, featuresRead: lines.length - 1, featuresComplete: rawFeatures.length };
+  }
+
+  if (duplicateFeatureIds.size > 0) {
+    return { ...emptyResult([`Feature IDs must be unique for traceable PCA loadings; duplicates: ${[...duplicateFeatureIds].slice(0, 6).join(", ")}.`], delimiterName), availableLayers, featuresRead: lines.length - 1, featuresComplete: rawFeatures.length };
   }
 
   if (rawFeatures.length < 2) {
     return { ...emptyResult(["The selected observation columns do not contain enough complete numeric feature rows."], delimiterName), availableLayers };
   }
 
-  const flattenedPreview = rawFeatures.slice(0, 500).flat();
-  const allNonNegative = flattenedPreview.every((value) => value >= 0);
-  const integerRatio = flattenedPreview.filter(Number.isInteger).length / Math.max(1, flattenedPreview.length);
   const inferredLayer: Exclude<PcaDataLayer, "auto"> = options.dataLayer !== "auto"
     ? options.dataLayer
-    : countColumns.length >= 3 || (allNonNegative && integerRatio >= 0.995)
+    : countColumns.length >= 3
       ? "counts"
-      : abundanceColumns.length >= 3 || allNonNegative
+      : abundanceColumns.length >= 3
         ? "abundance"
         : "normalized";
 
-  if ((inferredLayer === "counts" || inferredLayer === "abundance") && rawFeatures.some((feature) => feature.some((value) => value < 0))) {
+  if ((inferredLayer === "counts" || inferredLayer === "abundance") && rawFeatures.some((feature) => feature.values.some((value) => value < 0))) {
     return { ...emptyResult([`${inferredLayer === "counts" ? "Counts" : "Non-negative abundance values"} cannot contain negative values.`], delimiterName), availableLayers };
   }
 
-  const librarySizes = Array.from({ length: selectedColumns.length }, (_, sampleIndex) => rawFeatures.reduce((sum, feature) => sum + feature[sampleIndex], 0));
+  const librarySizes = Array.from({ length: selectedColumns.length }, (_, sampleIndex) => rawFeatures.reduce((sum, feature) => sum + feature.values[sampleIndex], 0));
   if (inferredLayer === "counts" && librarySizes.some((size) => size <= 0)) {
     return { ...emptyResult(["Every count-matrix observation must have a positive column total."], delimiterName), availableLayers };
   }
 
   const minimumSamples = Math.min(3, Math.max(2, Math.floor(selectedColumns.length / 4)));
   const transformed = rawFeatures.flatMap((feature) => {
-    if (inferredLayer === "counts" && feature.filter((value) => value >= 10).length < minimumSamples) return [];
+    if (inferredLayer === "counts" && feature.values.filter((value) => value >= 10).length < minimumSamples) return [];
     const values = inferredLayer === "counts"
-      ? feature.map((value, sampleIndex) => Math.log2((value / librarySizes[sampleIndex]) * 1_000_000 + 1))
+      ? feature.values.map((value, sampleIndex) => Math.log2((value / librarySizes[sampleIndex]) * 1_000_000 + 1))
       : inferredLayer === "abundance"
-        ? feature.map((value) => Math.log2(value + 1))
-        : feature;
+        ? feature.values.map((value) => Math.log2(value + 1))
+        : feature.values;
     const featureVariance = variance(values);
-    return featureVariance > 0 ? [{ values, variance: featureVariance }] : [];
+    return featureVariance > 0 ? [{ feature: feature.feature, values, variance: featureVariance }] : [];
   });
 
   transformed.sort((left, right) => right.variance - left.variance);
   const selectedFeatures = options.topVariableFeatures > 0 ? transformed.slice(0, options.topVariableFeatures) : transformed;
   if (selectedFeatures.length < 2) {
-    return { ...emptyResult(["Too few variable features remain after filtering."], delimiterName), availableLayers };
+    return { ...emptyResult(["Too few variable features remain after filtering."], delimiterName), availableLayers, featuresRead: lines.length - 1, featuresComplete: rawFeatures.length, featuresVariable: transformed.length };
   }
 
   const sampleCount = selectedColumns.length;
-  const gram = Array.from({ length: sampleCount }, () => Array(sampleCount).fill(0) as number[]);
+  if (selectedFeatures.length * sampleCount > 1_000_000) {
+    return { ...emptyResult([`Browser PCA is limited to one million selected feature-by-observation cells; detected ${(selectedFeatures.length * sampleCount).toLocaleString()}. Reduce top-variable features or import externally computed coordinates.`], delimiterName), availableLayers, featuresRead: lines.length - 1, featuresComplete: rawFeatures.length, featuresVariable: transformed.length };
+  }
+  const centeredFeatures: Array<{ feature: string; values: number[] }> = [];
   for (const feature of selectedFeatures) {
     const mean = feature.values.reduce((sum, value) => sum + value, 0) / sampleCount;
     const centered = feature.values.map((value) => value - mean);
@@ -273,44 +295,61 @@ export function analyzeExpressionMatrix(raw: string, options: PcaOptions = defau
       const standardDeviation = Math.sqrt(variance(feature.values));
       if (standardDeviation > 0) centered.forEach((value, index) => { centered[index] = value / standardDeviation; });
     }
-    for (let row = 0; row < sampleCount; row += 1) {
-      for (let column = row; column < sampleCount; column += 1) {
-        gram[row][column] += centered[row] * centered[column];
-      }
-    }
+    centeredFeatures.push({ feature: feature.feature, values: centered });
   }
   const denominator = Math.max(1, sampleCount - 1);
-  for (let row = 0; row < sampleCount; row += 1) {
-    for (let column = row; column < sampleCount; column += 1) {
-      gram[row][column] /= denominator;
-      gram[column][row] = gram[row][column];
-    }
+  const decomposition = nipalsPca(centeredFeatures.map((feature) => feature.values), 10, denominator);
+  if (!decomposition.converged) {
+    return { ...emptyResult(["PCA NIPALS solver did not converge for this matrix. Reduce the observation count or compute PCA in a documented external workflow."], delimiterName), availableLayers, featuresRead: lines.length - 1, featuresComplete: rawFeatures.length, featuresVariable: transformed.length };
   }
-
-  const components = symmetricEigenDecomposition(gram).filter((component) => component.value > 1e-12);
+  const components = decomposition.components.filter((component) => component.value > 1e-12);
   if (components.length < 2) {
-    return { ...emptyResult(["PCA needs at least two non-zero components; the selected observations may be identical."], delimiterName), availableLayers };
+    return { ...emptyResult(["PCA needs at least two non-zero components; the selected observations may be identical."], delimiterName), availableLayers, featuresRead: lines.length - 1, featuresComplete: rawFeatures.length, featuresVariable: transformed.length };
   }
-  const totalVariance = components.reduce((sum, component) => sum + component.value, 0);
+  const totalVariance = centeredFeatures.reduce((sum, feature) => sum + feature.values.reduce((rowSum, value) => rowSum + value * value, 0), 0) / denominator;
   const explainedVariance = components.map((component) => component.value / totalVariance);
-  const componentScores = components.slice(0, Math.min(10, components.length)).map((component) => {
-    const scale = Math.sqrt(component.value * denominator);
-    const scores = component.vector.map((value) => value * scale);
-    const anchor = scores.reduce((best, value) => Math.abs(value) > Math.abs(best) ? value : best, 0);
-    return anchor < 0 ? scores.map((value) => -value) : scores;
-  });
-  const sampleNames = selectedColumns.map(sampleNameFromColumn);
-  const groupValues = sampleNames.map(inferPcaGroup);
+  const componentScores = components.map((component) => component.scores);
+  const loadings = centeredFeatures.map((feature, featureIndex) => ({
+    feature: feature.feature,
+    coordinates: components.map((component) => component.loadings[featureIndex]),
+  }));
+  const metadataLines = normalizeLines(observationMetadataRaw);
+  const metadataErrors: string[] = [];
+  const metadataWarnings: string[] = [];
+  let metadataHeaders: string[] = [];
+  const metadataBySample = new Map<string, Record<string, string>>();
+  if (metadataLines.length > 0) {
+    const metadataDelimiter = detectDelimiter(metadataLines[0]);
+    const headers = splitLine(metadataLines[0], metadataDelimiter);
+    metadataHeaders = headers.slice(1);
+    if (headers.length < 2) metadataErrors.push("PCA observation metadata needs a sample-ID column and at least one annotation column.");
+    if (new Set(headers).size !== headers.length) metadataErrors.push("PCA observation metadata headers must be unique.");
+    if (metadataHeaders.some((header) => header === "sample" || /^PC\d+$/i.test(header))) metadataErrors.push("PCA observation metadata columns cannot be named sample or PC1, PC2, and so on.");
+    metadataLines.slice(1).forEach((line, rowIndex) => {
+      const cells = splitLine(line, metadataDelimiter);
+      if (cells.length !== headers.length) { metadataErrors.push(`PCA observation metadata row ${rowIndex + 2} has ${cells.length} fields; expected ${headers.length}.`); return; }
+      const sampleId = cells[0]?.trim();
+      if (!sampleId) { metadataErrors.push(`PCA observation metadata row ${rowIndex + 2} has a blank sample ID.`); return; }
+      if (metadataBySample.has(sampleId)) { metadataErrors.push(`PCA observation metadata sample IDs must be unique; duplicate: ${sampleId}.`); return; }
+      metadataBySample.set(sampleId, Object.fromEntries(metadataHeaders.map((header, index) => [header, cells[index + 1] ?? ""])));
+    });
+    const missing = sampleNames.filter((sample) => !metadataBySample.has(sample));
+    const extra = [...metadataBySample.keys()].filter((sample) => !sampleNames.includes(sample));
+    if (missing.length > 0) metadataErrors.push(`PCA observation metadata is missing ${missing.length} sample ID${missing.length === 1 ? "" : "s"}: ${missing.slice(0, 6).join(", ")}${missing.length > 6 ? "…" : ""}.`);
+    if (extra.length > 0) metadataWarnings.push(`${extra.length} PCA observation metadata row${extra.length === 1 ? " does" : "s do"} not match a matrix observation and will be ignored: ${extra.slice(0, 6).join(", ")}${extra.length > 6 ? "…" : ""}.`);
+  }
+  const groupValues = sampleNames.map((sample) => metadataBySample.get(sample)?.group ?? inferPcaGroup(sample));
   const groups = [...new Set(groupValues)];
   const rows = sampleNames.map((sample, sampleIndex) => Object.fromEntries([
     ["sample", sample],
     ["group", groupValues[sampleIndex]],
+    ...metadataHeaders.filter((header) => header !== "group").map((header) => [header, metadataBySample.get(sample)?.[header] ?? ""]),
     ...componentScores.map((scores, componentIndex) => [`PC${componentIndex + 1}`, formatScore(scores[sampleIndex])]),
   ]));
-  const warnings: string[] = [];
+  const warnings: string[] = [...metadataWarnings];
   if (malformedRows > 0) warnings.push(`${malformedRows} malformed feature row${malformedRows === 1 ? " was" : "s were"} skipped.`);
   if (incompleteRows > 0) warnings.push(`${incompleteRows} feature row${incompleteRows === 1 ? " was" : "s were"} skipped because selected observation values were incomplete.`);
-  if (options.dataLayer === "auto") warnings.push(`Auto-detected ${inferredLayer === "counts" ? "count-like values" : inferredLayer === "abundance" ? "non-negative abundance values" : "continuous / already normalized values"}.`);
+  if (options.dataLayer === "auto") warnings.push(inferredLayer === "counts" ? "Auto-detected count columns from explicit _count/_counts suffixes." : inferredLayer === "abundance" ? "Auto-detected abundance columns from explicit _tpm/_fpkm suffixes." : "No explicit count/TPM/FPKM suffixes were detected; values were treated as continuous / already normalized without a log transform.");
 
   const transformation = inferredLayer === "counts"
     ? `Features with count ≥10 in at least ${minimumSamples} observations; log₂(CPM + 1)`
@@ -321,20 +360,24 @@ export function analyzeExpressionMatrix(raw: string, options: PcaOptions = defau
 
   return {
     dataset: {
-      headers: ["sample", "group", ...componentScores.map((_, index) => `PC${index + 1}`)],
+      headers: ["sample", "group", ...metadataHeaders.filter((header) => header !== "group"), ...componentScores.map((_, index) => `PC${index + 1}`)],
       rows,
       delimiter: delimiterName,
-      errors: [],
+      errors: metadataErrors,
       warnings,
+      analysis: { pca: { explainedVariance, loadings } },
     },
     detectedLayer: inferredLayer,
     sampleColumns: selectedColumns,
     sampleNames,
     groups,
     availableLayers,
-    featuresRead: rawFeatures.length,
+    featuresRead: lines.length - 1,
+    featuresComplete: rawFeatures.length,
+    featuresVariable: transformed.length,
     featuresUsed: selectedFeatures.length,
     explainedVariance,
+    loadings,
     transformation,
   };
 }

--- a/src/lib/visualization-studio.test.ts
+++ b/src/lib/visualization-studio.test.ts
@@ -4,6 +4,7 @@ import {
   categoricalColorForIndex,
   boxStatistics,
   confidenceInterval95,
+  compactLegendLabel,
   covarianceEllipsePoints,
   defaultVisualizationPaletteSeriesId,
   defaultVisualizationSettings,
@@ -23,6 +24,8 @@ import {
   loessSmooth,
   meanErrorStatistics,
   numericExtent,
+  ordinationLoadingLayout,
+  ordinationLegendLayout,
   parseDelimitedData,
   parseRatioValue,
   polynomialRegression,
@@ -105,11 +108,11 @@ describe("Visualization Studio data contracts", () => {
   it("ships every requested first-batch plot type with a sample data contract", () => {
     const requested = [
       "scatter", "correlation", "volcano", "ma", "quadrant", "bar", "errorbar", "line", "area", "lollipop",
-      "box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "clustered-heatmap", "correlation-heatmap", "pca", "pcoa", "umap",
+      "box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "clustered-heatmap", "correlation-heatmap", "pca", "pcoa", "umap", "tsne", "nmds",
       "enrichment", "enrichment-bar", "gsea", "km", "survival-forest", "roc", "venn", "upset", "sankey", "chord", "circos",
       "pie", "donut", "rose", "waffle", "treemap", "sunburst", "radar", "polar-profile", "population-pyramid",
     ];
-    expect(plotDefinitions).toHaveLength(43);
+    expect(plotDefinitions).toHaveLength(45);
     expect(requested.every((id) => plotDefinitions.some((definition) => definition.id === id && definition.sampleData.length > 20))).toBe(true);
     plotDefinitions.forEach((definition) => {
       const examples = getPlotExamples(definition);
@@ -123,12 +126,17 @@ describe("Visualization Studio data contracts", () => {
 
   it("uses representative demo sizes for dense scientific plots", () => {
     const umap = parseDelimitedData(getPlotDefinition("umap").sampleData);
+    const tsne = parseDelimitedData(getPlotDefinition("tsne").sampleData);
+    const nmds = parseDelimitedData(getPlotDefinition("nmds").sampleData);
     const gsea = parseDelimitedData(getPlotDefinition("gsea").sampleData);
     const survival = parseDelimitedData(getPlotDefinition("km").sampleData);
     const roc = parseDelimitedData(getPlotDefinition("roc").sampleData);
     const heatmap = parseDelimitedData(getPlotDefinition("heatmap").sampleData);
     expect(umap.rows.length).toBeGreaterThanOrEqual(60);
     expect(new Set(umap.rows.map((row) => row.group)).size).toBe(3);
+    expect(tsne.rows.length).toBeGreaterThanOrEqual(40);
+    expect(nmds.rows.length).toBeGreaterThanOrEqual(40);
+    expect(tsne.headers).toEqual(expect.arrayContaining(["dim1", "dim2", "dim3", "group", "shape"]));
     expect(gsea.rows).toHaveLength(100);
     expect(Number(gsea.rows[0].runningES)).toBeCloseTo(0, 1);
     expect(Number(gsea.rows.at(-1)?.runningES)).toBe(0);
@@ -141,6 +149,89 @@ describe("Visualization Studio data contracts", () => {
     expect(new Set(roc.rows.map((row) => row.model))).toEqual(new Set(["Model A", "Model B"]));
     expect(heatmap.rows).toHaveLength(24);
     expect(heatmap.headers).toHaveLength(13);
+  });
+
+  it("validates ordination overlays, upstream metadata, and 3D contracts", () => {
+    const pcoa = getPlotDefinition("pcoa");
+    const dataset = parseDelimitedData(pcoa.sampleData);
+    const mapping = pcoa.defaultMapping;
+    expect(validatePlotDataset(pcoa, dataset, { ...mapping, z: "" }, { ...defaultVisualizationSettings, ordinationView: "3d" }).errors.join(" ")).toMatch(/third coordinate/);
+    expect(validatePlotDataset(pcoa, dataset, { ...mapping, y: "dim1" }, defaultVisualizationSettings).errors.join(" ")).toMatch(/different coordinate column/);
+    expect(validatePlotDataset(pcoa, dataset, mapping, { ...defaultVisualizationSettings, ordinationXVariance: 45 }).errors.join(" ")).toMatch(/every displayed PCoA coordinate/);
+    expect(validatePlotDataset(pcoa, dataset, mapping, { ...defaultVisualizationSettings, ordinationXVariance: 70, ordinationYVariance: 40 }).errors.join(" ")).toMatch(/sum to more than 100/);
+    const remappedVariance = validatePlotDataset(pcoa, dataset, { ...mapping, x: "dim3", y: "dim1" }, { ...defaultVisualizationSettings, ordinationXVariance: 41.2, ordinationZVariance: 11.3 });
+    expect(remappedVariance.errors).toEqual([]);
+    expect(validatePlotDataset(pcoa, dataset, mapping, { ...defaultVisualizationSettings, ordinationPermanovaR2: 0.24 }).errors.join(" ")).toMatch(/requires R², P value, and permutation count/);
+    const validPermanova = validatePlotDataset(pcoa, dataset, mapping, { ...defaultVisualizationSettings, ordinationPermanovaR2: 0.24, ordinationPermanovaP: 0.013, ordinationPermanovaPermutations: 999, ordinationMethodNote: "Bray-Curtis; group; unrestricted permutations" });
+    expect(validPermanova.errors).toEqual([]);
+    expect(validPermanova.warnings.join(" ")).toMatch(/displayed as supplied/);
+    expect(validatePlotDataset(pcoa, dataset, mapping, { ...defaultVisualizationSettings, ordinationPermanovaR2: 0.24, ordinationPermanovaP: 0.013, ordinationPermanovaPermutations: 999 }).errors.join(" ")).toMatch(/method note/);
+
+    const oneGroup = parseDelimitedData("dim1\tdim2\tdim3\tgroup\tsample\n0\t0\t0\tOnly\tS1\n1\t1\t1\tOnly\tS2\n2\t2\t2\tOnly\tS3");
+    expect(validatePlotDataset(pcoa, oneGroup, mapping, { ...defaultVisualizationSettings, ordinationPermanovaR2: 0.2, ordinationPermanovaP: 0.03, ordinationPermanovaPermutations: 999, ordinationMethodNote: "Euclidean; group; unrestricted permutations" }).errors.join(" ")).toMatch(/at least two non-empty levels/);
+
+    const noGroup = validatePlotDataset(pcoa, dataset, { ...mapping, group: "" }, { ...defaultVisualizationSettings, ordinationShowEllipse: true });
+    expect(noGroup.errors.join(" ")).toMatch(/Map a group column/);
+    const tooManyShapes = parseDelimitedData("dim1\tdim2\tdim3\tgroup\tshape\tsample\n0\t0\t0\tG\tA\tS1\n1\t0\t0\tG\tB\tS2\n0\t1\t0\tG\tC\tS3\n1\t1\t1\tG\tD\tS4\n2\t1\t1\tG\tE\tS5");
+    expect(validatePlotDataset(pcoa, tooManyShapes, mapping, { ...defaultVisualizationSettings, ordinationUseShapes: true }).errors.join(" ")).toMatch(/at most four distinct shapes/);
+
+    const nmds = getPlotDefinition("nmds");
+    expect(validatePlotDataset(nmds, parseDelimitedData(nmds.sampleData), nmds.defaultMapping, { ...defaultVisualizationSettings, ordinationStress: -0.1 }).errors.join(" ")).toMatch(/stress must be non-negative/);
+
+    const pca = getPlotDefinition("pca");
+    const pcaDataset = { ...parseDelimitedData("sample\tgroup\tPC1\tPC2\nS1\tA\t1\t2\nS2\tB\t2\t1"), analysis: { pca: { explainedVariance: [0.7, 0.3], loadings: [] } } };
+    const hiddenLayerSettings = { ...defaultVisualizationSettings, ordinationView: "scree" as const, ordinationShowEllipse: true, ordinationShowHull: true, ordinationUseShapes: true, ordinationPermanovaR2: 4, ordinationPermanovaP: -1, ordinationPermanovaPermutations: -5 };
+    expect(validatePlotDataset(pca, pcaDataset, {}, hiddenLayerSettings).errors).toEqual([]);
+    const loadingDataset = { ...pcaDataset, analysis: { pca: { explainedVariance: [0.7, 0.3], loadings: [{ feature: "A", coordinates: [-0.8, 0.4] }] } } };
+    expect(validatePlotDataset(pca, loadingDataset, { x: "PC1", y: "PC2", group: "group", label: "sample" }, { ...defaultVisualizationSettings, ordinationShowLoadings: true, xMin: -0.1, xMax: 10 }).errors.join(" ")).toMatch(/every visible arrow and label/);
+    expect(validatePlotDataset(pca, loadingDataset, { x: "PC1", y: "PC2", group: "group", label: "sample" }, { ...defaultVisualizationSettings, ordinationShowLoadings: true, xMin: -4, xMax: 6 }).errors).toEqual([]);
+    const annotatedOverlayDataset = {
+      ...parseDelimitedData("sample\tgroup\tPC1\tPC2\nA1\tA\t1.0\t1.0\nA2\tA\t1.3\t1.2\nA3\tA\t0.8\t1.4\nB1\tB\t2.0\t2.0\nB2\tB\t2.4\t2.1\nB3\tB\t1.9\t2.5"),
+      analysis: { pca: { explainedVariance: [0.7, 0.3], loadings: [{ feature: "LongFeatureName", coordinates: [0.2, -0.9] }] } },
+    };
+    const annotatedOverlaySettings = {
+      ...defaultVisualizationSettings,
+      ordinationShowLoadings: true,
+      ordinationShowEllipse: true,
+      ordinationPermanovaR2: 0.21,
+      ordinationPermanovaP: 0.012,
+      ordinationPermanovaPermutations: 999,
+      ordinationMethodNote: "Euclidean distance; group tested with cohort strata and restricted permutations",
+      yMin: -0.001,
+    };
+    const annotatedMapping = { x: "PC1", y: "PC2", group: "group", label: "sample" };
+    expect(validatePlotDataset(pca, annotatedOverlayDataset, annotatedMapping, annotatedOverlaySettings).errors.join(" ")).toMatch(/final annotated plot/);
+    expect(ordinationLoadingLayout(annotatedOverlayDataset, annotatedMapping, annotatedOverlaySettings).minimumArrowLength).toBeLessThan(2);
+    const safeAnnotatedSettings = { ...annotatedOverlaySettings, yMin: -4, yMax: 6 };
+    expect(validatePlotDataset(pca, annotatedOverlayDataset, annotatedMapping, safeAnnotatedSettings).errors).toEqual([]);
+    expect(ordinationLoadingLayout(annotatedOverlayDataset, annotatedMapping, safeAnnotatedSettings).minimumArrowLength).toBeGreaterThanOrEqual(2);
+    const crowdedLegendData = parseDelimitedData(`dim1\tdim2\tgroup\tshape\tsample\n${Array.from({ length: 12 }, (_, index) => `${index}\t${index % 3}\tG${index + 1}\tShape${index % 4 + 1}\tS${index + 1}`).join("\n")}`);
+    const crowdedLegendMapping = { x: "dim1", y: "dim2", group: "group", shape: "shape", label: "sample" };
+    const crowdedLegendSettings = { ...defaultVisualizationSettings, ordinationMethodNote: "Long upstream annotation describing distance transformation normalization and reproducible coordinate generation" };
+    expect(ordinationLegendLayout("pcoa", crowdedLegendSettings, 12, 4).fits).toBe(false);
+    expect(compactLegendLabel("ExtremelyWideGroupName", 11, 90, 24)).toMatch(/^.{2,}…$/);
+    expect(validatePlotDataset(pcoa, crowdedLegendData, crowdedLegendMapping, crowdedLegendSettings).errors.join(" ")).toMatch(/combined ordination color and shape legends/);
+    const tallLegendSettings = { ...crowdedLegendSettings, height: 640 };
+    expect(ordinationLegendLayout("pcoa", tallLegendSettings, 12, 4).fits).toBe(true);
+    expect(validatePlotDataset(pcoa, crowdedLegendData, crowdedLegendMapping, tallLegendSettings).errors).toEqual([]);
+    const manyGroupRows = Array.from({ length: 13 }, (_, index) => ({ sample: `S${index + 1}`, group: `G${index + 1}`, PC1: String(index), PC2: String(index % 3) }));
+    expect(validatePlotDataset(pca, { ...pcaDataset, rows: manyGroupRows }, { group: "group" }, hiddenLayerSettings).errors).toEqual([]);
+
+    const nmdsWithStress = parseDelimitedData(nmds.sampleData);
+    expect(validatePlotDataset(nmds, nmdsWithStress, nmds.defaultMapping, { ...defaultVisualizationSettings, ordinationStress: 0.12 }).errors.join(" ")).toMatch(/stress requires a method note/);
+    expect(validatePlotDataset(nmds, nmdsWithStress, nmds.defaultMapping, { ...defaultVisualizationSettings, ordinationStress: 0.12, ordinationMethodNote: "Kruskal stress-1; Bray-Curtis; k=2; converged" }).errors).toEqual([]);
+  });
+
+  it("preserves precomputed embedding coordinates verbatim", () => {
+    for (const type of ["pcoa", "umap", "tsne", "nmds"] as const) {
+      const definition = getPlotDefinition(type);
+      const firstInputRow = definition.sampleData.split("\n")[1].split("\t");
+      const dataset = parseDelimitedData(definition.sampleData);
+      expect(dataset.analysis).toBeUndefined();
+      expect(dataset.rows[0].dim1).toBe(firstInputRow[1]);
+      expect(dataset.rows[0].dim2).toBe(firstInputRow[2]);
+      expect(dataset.rows[0].dim3).toBe(firstInputRow[3]);
+    }
   });
 
   it("shows all four Chai-dyed Brown categorical colors in the default bar demo", () => {

--- a/src/lib/visualization-studio.ts
+++ b/src/lib/visualization-studio.ts
@@ -12,6 +12,8 @@ export type PlotType =
   | "pca"
   | "pcoa"
   | "umap"
+  | "tsne"
+  | "nmds"
   | "box"
   | "violin"
   | "beeswarm"
@@ -84,6 +86,12 @@ export type ParsedDataset = {
   delimiter: "tab" | "comma";
   errors: string[];
   warnings: string[];
+  analysis?: {
+    pca?: {
+      explainedVariance: number[];
+      loadings: Array<{ feature: string; coordinates: number[] }>;
+    };
+  };
 };
 
 export type FieldRole = {
@@ -118,6 +126,7 @@ export type PlotDataExample = {
   description: string;
   data: string;
   mapping?: Record<string, string>;
+  metadata?: string;
 };
 
 export type PlotReference = {
@@ -256,6 +265,21 @@ export type VisualizationSettings = {
   heatmapLabelDensity: "auto" | "all" | "none";
   heatmapRowAnnotationData: string;
   heatmapColumnAnnotationData: string;
+  ordinationView: "scores" | "scree" | "3d";
+  ordinationShowEllipse: boolean;
+  ordinationShowHull: boolean;
+  ordinationShowCentroids: boolean;
+  ordinationShowLoadings: boolean;
+  ordinationLoadingCount: number;
+  ordinationUseShapes: boolean;
+  ordinationXVariance: number | null;
+  ordinationYVariance: number | null;
+  ordinationZVariance: number | null;
+  ordinationPermanovaR2: number | null;
+  ordinationPermanovaP: number | null;
+  ordinationPermanovaPermutations: number | null;
+  ordinationStress: number | null;
+  ordinationMethodNote: string;
   correlationMethod: "pearson" | "spearman";
   xThreshold: number;
   yThreshold: number;
@@ -360,6 +384,21 @@ export const defaultVisualizationSettings: VisualizationSettings = {
   heatmapLabelDensity: "auto",
   heatmapRowAnnotationData: "",
   heatmapColumnAnnotationData: "",
+  ordinationView: "scores",
+  ordinationShowEllipse: false,
+  ordinationShowHull: false,
+  ordinationShowCentroids: false,
+  ordinationShowLoadings: false,
+  ordinationLoadingCount: 8,
+  ordinationUseShapes: true,
+  ordinationXVariance: null,
+  ordinationYVariance: null,
+  ordinationZVariance: null,
+  ordinationPermanovaR2: null,
+  ordinationPermanovaP: null,
+  ordinationPermanovaPermutations: null,
+  ordinationStress: null,
+  ordinationMethodNote: "",
   correlationMethod: "pearson",
   xThreshold: 0,
   yThreshold: 0,
@@ -381,6 +420,192 @@ export const defaultVisualizationSettings: VisualizationSettings = {
   divergingMid: "#FAF7F2",
   divergingHigh: "#D3BBA4",
 };
+
+export type OrdinationType = "pca" | "pcoa" | "umap" | "tsne" | "nmds";
+
+export function ordinationAnnotationLayout(type: OrdinationType, settings: VisualizationSettings) {
+  const sources = [
+    settings.ordinationPermanovaR2 !== null && settings.ordinationPermanovaP !== null && settings.ordinationPermanovaPermutations !== null
+      ? `PERMANOVA (supplied) · R²=${settings.ordinationPermanovaR2.toFixed(3)} · p=${settings.ordinationPermanovaP < 0.001 ? "<0.001" : settings.ordinationPermanovaP.toFixed(3)} · nperm=${settings.ordinationPermanovaPermutations}`
+      : "",
+    type === "nmds" && settings.ordinationStress !== null ? `Supplied NMDS stress = ${settings.ordinationStress.toFixed(3)}` : "",
+    settings.ordinationMethodNote.trim() ? `Upstream: ${settings.ordinationMethodNote.trim().slice(0, 72)}` : "",
+  ].filter(Boolean);
+  const fontSize = Math.max(8, settings.legendSize - 1);
+  const charactersPerLine = Math.max(28, Math.floor((settings.width - 28) / (fontSize * 0.56)));
+  const lines = sources.flatMap((source) => {
+    const words = source.split(/\s+/);
+    const wrapped: string[] = [];
+    let line = "";
+    words.forEach((word) => {
+      if (!line || `${line} ${word}`.length <= charactersPerLine) line = line ? `${line} ${word}` : word;
+      else { wrapped.push(line); line = word; }
+    });
+    if (line) wrapped.push(line);
+    return wrapped;
+  });
+  return { lines, fontSize, lineHeight: Math.max(11, settings.legendSize + 3) };
+}
+
+/** Shared ordination plot geometry used by validation and SVG rendering. */
+export function ordinationFrameMetrics(type: OrdinationType, settings: VisualizationSettings) {
+  const left = 66;
+  const top = settings.title ? 48 : 24;
+  const bottom = settings.legendPosition === "bottom" ? 80 : 58;
+  const right = 22 + (settings.legendPosition === "right" ? 145 : 0);
+  const plotWidth = Math.max(100, settings.width - left - right);
+  const basePlotHeight = Math.max(90, settings.height - top - bottom);
+  const annotation = ordinationAnnotationLayout(type, settings);
+  const annotationHeight = annotation.lines.length * annotation.lineHeight;
+  return {
+    width: settings.width,
+    height: settings.height,
+    left,
+    right,
+    top: top + annotationHeight,
+    bottom,
+    plotWidth,
+    plotHeight: annotation.lines.length ? Math.max(80, basePlotHeight - annotationHeight) : basePlotHeight,
+    annotation,
+    annotationTop: top,
+  };
+}
+
+export function ordinationLegendLayout(
+  type: OrdinationType,
+  settings: VisualizationSettings,
+  groupCount: number,
+  shapeCount: number,
+) {
+  const frame = ordinationFrameMetrics(type, settings);
+  const visibleGroups = Math.min(12, groupCount);
+  const visibleShapes = Math.min(4, shapeCount);
+  const hasColorLegend = settings.legendPosition !== "none" && visibleGroups >= 2;
+  const hasShapeLegend = settings.legendPosition !== "none" && settings.ordinationUseShapes && visibleShapes >= 2;
+  if (settings.legendPosition === "none") return { fits: true, shapeX: frame.left, shapeY: frame.height, colorBottom: frame.top, shapeBottom: frame.top };
+  if (settings.legendPosition === "right") {
+    const colorBottom = hasColorLegend
+      ? frame.top + 5 + (visibleGroups - 1) * (settings.legendSize + 10) + settings.legendSize
+      : frame.top;
+    const shapeX = frame.left + frame.plotWidth + 10;
+    const shapeY = frame.top + visibleGroups * (settings.legendSize + 8) + 20;
+    const shapeBottom = hasShapeLegend
+      ? shapeY + 17 + (visibleShapes - 1) * (settings.legendSize + 6)
+      : frame.top;
+    return { fits: Math.max(colorBottom, shapeBottom) <= settings.height - 4, shapeX, shapeY, colorBottom, shapeBottom };
+  }
+  const groupsPerRow = Math.max(2, Math.min(4, Math.floor(frame.plotWidth / 90)));
+  const colorRows = hasColorLegend ? Math.ceil(visibleGroups / groupsPerRow) : 0;
+  const colorBottom = colorRows ? frame.height - 72 + (colorRows - 1) * (settings.legendSize + 7) + settings.legendSize : frame.top;
+  const shapeX = frame.left;
+  const shapeY = frame.height - 24;
+  const shapeBottom = hasShapeLegend ? shapeY + 17 : frame.top;
+  const conservativeShapeRight = hasShapeLegend ? shapeX + (visibleShapes - 1) * 74 + 12 + 10 * Math.max(8, settings.legendSize - 1) : shapeX;
+  const noVerticalCollision = !hasColorLegend || !hasShapeLegend || colorBottom + 4 < shapeY;
+  return { fits: noVerticalCollision && shapeBottom <= settings.height - 4 && conservativeShapeRight <= settings.width - 4, shapeX, shapeY, colorBottom, shapeBottom };
+}
+
+export function estimateLegendTextWidth(label: string, fontSize: number) {
+  const em = [...label].reduce((sum, character) => {
+    if (character === "…") return sum + 1;
+    if (/[^\u0000-\u00ff]/.test(character)) return sum + 1;
+    if (/[WM@%&]/.test(character)) return sum + 0.98;
+    if (/[A-Z]/.test(character)) return sum + 0.74;
+    if (/[a-z0-9]/.test(character)) return sum + 0.62;
+    if (/\s/.test(character)) return sum + 0.34;
+    return sum + 0.46;
+  }, 0);
+  return em * Math.max(1, fontSize);
+}
+
+/** Character-aware conservative truncation keeps Arial legend text inside its assigned cell. */
+export function compactLegendLabel(label: string, fontSize: number, availablePixels: number, maximumCharacters: number) {
+  const maximum = Math.max(1, maximumCharacters);
+  if (label.length <= maximum && estimateLegendTextWidth(label, fontSize) <= availablePixels) return label;
+  for (let capacity = Math.min(maximum, label.length); capacity >= 2; capacity -= 1) {
+    const candidate = `${label.slice(0, capacity - 1)}…`;
+    if (estimateLegendTextWidth(candidate, fontSize) <= availablePixels) return candidate;
+  }
+  return "…";
+}
+
+export function ordinationScoreDomains(
+  type: OrdinationType,
+  dataset: ParsedDataset,
+  mapping: Record<string, string>,
+  settings: VisualizationSettings,
+) {
+  const displayedXColumn = type === "pca" && settings.swapAxes ? mapping.y : mapping.x;
+  const displayedYColumn = type === "pca" && settings.swapAxes ? mapping.x : mapping.y;
+  const points = dataset.rows.map((row) => ({
+    x: parseNumericValue(row[displayedXColumn]) ?? 0,
+    y: parseNumericValue(row[displayedYColumn]) ?? 0,
+    group: mapping.group ? row[mapping.group] || "All" : "All",
+  }));
+  const groups = [...new Set(points.map((point) => point.group))];
+  const ellipseBoundary = settings.ordinationShowEllipse
+    ? groups.flatMap((group) => covarianceEllipsePoints(points.filter((point) => point.group === group)))
+    : [];
+  // A convex hull cannot extend beyond the raw extrema, so raw points plus the
+  // covariance boundary fully determine the renderer's automatic score domain.
+  const rawXExtent = numericExtent([...points.map((point) => point.x), ...ellipseBoundary.map((point) => point.x)]);
+  const rawYExtent = numericExtent([...points.map((point) => point.y), ...ellipseBoundary.map((point) => point.y)]);
+  const symmetricExtent = (extent: [number, number]): [number, number] => {
+    const maximum = Math.max(Math.abs(extent[0]), Math.abs(extent[1]), 1e-6);
+    return [-maximum, maximum];
+  };
+  return {
+    displayedXColumn,
+    displayedYColumn,
+    xDomain: resolveAxisDomain(settings.ordinationShowLoadings && type === "pca" && settings.xMin === null && settings.xMax === null ? symmetricExtent(rawXExtent) : rawXExtent, settings.xMin, settings.xMax),
+    yDomain: resolveAxisDomain(settings.ordinationShowLoadings && type === "pca" && settings.yMin === null && settings.yMax === null ? symmetricExtent(rawYExtent) : rawYExtent, settings.yMin, settings.yMax),
+  };
+}
+
+export function ordinationLoadingLayout(
+  dataset: ParsedDataset,
+  mapping: Record<string, string>,
+  settings: VisualizationSettings,
+) {
+  const frame = ordinationFrameMetrics("pca", settings);
+  const domains = ordinationScoreDomains("pca", dataset, mapping, settings);
+  const componentIndex = (header: string) => Math.max(0, Number(header?.match(/\d+/)?.[0] ?? 1) - 1);
+  const selected = (dataset.analysis?.pca?.loadings ?? [])
+    .map((loading) => ({
+      feature: loading.feature,
+      x: loading.coordinates[componentIndex(domains.displayedXColumn)] ?? 0,
+      y: loading.coordinates[componentIndex(domains.displayedYColumn)] ?? 0,
+    }))
+    .filter((loading) => Math.hypot(loading.x, loading.y) > Number.EPSILON)
+    .sort((left, right) => Math.hypot(right.x, right.y) - Math.hypot(left.x, left.y))
+    .slice(0, settings.ordinationLoadingCount);
+  const loadingMaximum = Math.max(...selected.flatMap((loading) => [Math.abs(loading.x), Math.abs(loading.y)]), Number.EPSILON);
+  const originX = scaleLinear(0, domains.xDomain, [frame.left, frame.left + frame.plotWidth]);
+  const originY = scaleLinear(0, domains.yDomain, [frame.top + frame.plotHeight, frame.top]);
+  const fontSize = Math.max(8, settings.tickSize - 1);
+  const labelCapacity = Math.max(2, Math.min(12, Math.floor((frame.plotWidth * 0.5 - 14) / fontSize)));
+  const desired = selected.map((loading) => ({
+    ...loading,
+    displayFeature: loading.feature.length <= labelCapacity ? loading.feature : `${loading.feature.slice(0, Math.max(1, labelCapacity - 1))}…`,
+    dx: loading.x / loadingMaximum * frame.plotWidth * 0.28,
+    dy: -loading.y / loadingMaximum * frame.plotHeight * 0.28,
+  }));
+  const safetyScale = Math.max(0, Math.min(1, ...desired.flatMap((loading) => {
+    const labelWidth = loading.displayFeature.length * fontSize + 5;
+    const horizontal = loading.dx > 0 ? (frame.left + frame.plotWidth - originX - labelWidth) / loading.dx : loading.dx < 0 ? (originX - frame.left - labelWidth) / -loading.dx : 1;
+    const vertical = loading.dy > 0 ? (frame.top + frame.plotHeight - originY - 3) / loading.dy : loading.dy < 0 ? (originY - frame.top - fontSize - 3) / -loading.dy : 1;
+    return [horizontal, vertical];
+  })));
+  const geometries = desired.map((loading) => ({
+    ...loading,
+    endX: originX + loading.dx * safetyScale,
+    endY: originY + loading.dy * safetyScale,
+  }));
+  const minimumArrowLength = geometries.length
+    ? Math.min(...geometries.map((loading) => Math.hypot(loading.endX - originX, loading.endY - originY)))
+    : Number.POSITIVE_INFINITY;
+  return { frame, ...domains, originX, originY, fontSize, safetyScale, geometries, minimumArrowLength };
+}
 
 export const journalThemes: Record<JournalThemeId, JournalTheme> = {
   nature: {
@@ -612,9 +837,29 @@ function buildUmapExample() {
     const radius = 0.18 + 0.11 * Math.sqrt(index + 1);
     const x = cx + Math.cos(angle) * radius * 1.35 + Math.sin(index * 0.73) * 0.12;
     const y = cy + Math.sin(angle) * radius * 0.82 + Math.cos(index * 0.51) * 0.1;
-    return `${group.slice(0, 3)}_${String(index + 1).padStart(2, "0")}\t${x.toFixed(3)}\t${y.toFixed(3)}\t${group}`;
+    const z = Math.sin(angle * 0.7) * 0.9 + (group === "Responder" ? -0.7 : group === "Resistant" ? 0.8 : 0);
+    const batch = index % 2 === 0 ? "Batch 1" : "Batch 2";
+    return `${group.slice(0, 3)}_${String(index + 1).padStart(2, "0")}\t${x.toFixed(3)}\t${y.toFixed(3)}\t${z.toFixed(3)}\t${group}\t${batch}`;
   }));
-  return `sample\tdim1\tdim2\tgroup\n${rows.join("\n")}`;
+  return `sample\tdim1\tdim2\tdim3\tgroup\tshape\n${rows.join("\n")}`;
+}
+
+function buildOrdinationExample(kind: "pcoa" | "tsne" | "nmds") {
+  const clusters = kind === "nmds"
+    ? [{ group: "Forest", cx: -0.62, cy: 0.28 }, { group: "Grassland", cx: 0.04, cy: -0.42 }, { group: "Wetland", cx: 0.62, cy: 0.31 }]
+    : kind === "tsne"
+      ? [{ group: "Type A", cx: -7.2, cy: 4.8 }, { group: "Type B", cx: 0.4, cy: -5.6 }, { group: "Type C", cx: 7.4, cy: 3.9 }]
+      : [{ group: "Control", cx: -2.4, cy: 0.8 }, { group: "Treatment A", cx: 0.15, cy: -1.55 }, { group: "Treatment B", cx: 2.55, cy: 0.95 }];
+  const rows = clusters.flatMap(({ group, cx, cy }, groupIndex) => Array.from({ length: 14 }, (_, index) => {
+    const angle = index * 2.3999632297 + groupIndex * 0.37;
+    const scale = kind === "nmds" ? 0.055 : kind === "tsne" ? 0.58 : 0.2;
+    const radius = (1.3 + Math.sqrt(index + 1) * 0.42) * scale;
+    const x = cx + Math.cos(angle) * radius * 1.25;
+    const y = cy + Math.sin(angle) * radius * 0.78;
+    const z = groupIndex * 0.8 - 0.8 + Math.sin(angle * 0.8) * scale * 2;
+    return `${group.replaceAll(" ", "_").slice(0, 5)}_${String(index + 1).padStart(2, "0")}\t${x.toFixed(4)}\t${y.toFixed(4)}\t${z.toFixed(4)}\t${group}\t${index % 2 === 0 ? "Cohort 1" : "Cohort 2"}`;
+  }));
+  return `sample\tdim1\tdim2\tdim3\tgroup\tshape\n${rows.join("\n")}`;
 }
 
 function buildGseaExample() {
@@ -781,6 +1026,13 @@ Feature_E\t1.0\t1.2\t1.1\t4.6\t4.3\t4.8
 Feature_F\t15.8\t15.1\t16.0\t9.2\t8.8\t9.5
 Feature_G\t4.9\t5.1\t4.7\t11.3\t11.9\t10.8
 Feature_H\t3.6\t3.4\t3.8\t3.7\t3.5\t3.9`,
+  pcaMetadata: `sample\tgroup\tbatch\tlabel
+Control_1\tControl\tBatch 1\tC1
+Control_2\tControl\tBatch 2\tC2
+Control_3\tControl\tBatch 1\tC3
+Treatment_1\tTreatment\tBatch 2\tT1
+Treatment_2\tTreatment\tBatch 1\tT2
+Treatment_3\tTreatment\tBatch 2\tT3`,
   distribution: `group\tvalue
 Control\t4.1
 Control\t4.6
@@ -873,14 +1125,10 @@ DNA repair\t6.8\tBP
 PI3K-AKT\t5.9\tKEGG
 p53 signaling\t4.7\tKEGG
 Apoptosis\t3.8\tBP`,
-  pcoa: `sample\tdim1\tdim2\tgroup
-Control_1\t-2.1\t0.8\tControl
-Control_2\t-1.6\t1.2\tControl
-Control_3\t-1.9\t0.2\tControl
-Treatment_1\t1.4\t-0.5\tTreatment
-Treatment_2\t2.0\t-0.9\tTreatment
-Treatment_3\t1.7\t0.1\tTreatment`,
+  pcoa: buildOrdinationExample("pcoa"),
   umap: buildUmapExample(),
+  tsne: buildOrdinationExample("tsne"),
+  nmds: buildOrdinationExample("nmds"),
   gsea: buildGseaExample(),
   km: buildKaplanMeierExample(),
   forest: `label\testimate\tlower\tupper\tgroup
@@ -1047,14 +1295,16 @@ const plotDefinitionSeeds: PlotDefinition[] = [
     roles: [
       { key: "x", label: "X component", kind: "number", required: true },
       { key: "y", label: "Y component", kind: "number", required: true },
+      { key: "z", label: "Z component (3D only)", kind: "number", required: false },
       { key: "group", label: "Group", kind: "category", required: false },
+      { key: "shape", label: "Shape", kind: "category", required: false },
       { key: "label", label: "Observation label", kind: "label", required: false },
     ],
-    defaultMapping: { x: "PC1", y: "PC2", group: "group", label: "sample" },
+    defaultMapping: { x: "PC1", y: "PC2", z: "PC3", group: "group", shape: "", label: "sample" },
     sampleData: samples.pca,
     examples: [
-      { label: "Example 1", description: "Wide feature matrix with raw count columns.", data: samples.pca },
-      { label: "Example 2", description: "Wide feature matrix with TPM/abundance columns.", data: samples.pcaAbundance },
+      { label: "Example 1", description: "Wide feature matrix with raw count columns plus sample metadata joined by exact sample ID.", data: samples.pca, metadata: samples.pcaMetadata, mapping: { x: "PC1", y: "PC2", z: "PC3", group: "group", shape: "batch", label: "label" } },
+      { label: "Example 2", description: "Wide TPM/abundance matrix plus sample metadata joined by exact sample ID.", data: samples.pcaAbundance, metadata: samples.pcaMetadata, mapping: { x: "PC1", y: "PC2", z: "PC3", group: "group", shape: "batch", label: "label" } },
     ],
   },
   {
@@ -1254,20 +1504,26 @@ const plotDefinitionSeeds: PlotDefinition[] = [
       { label: "Example 2", description: "Paired observations with subject IDs, facets, and supplied group P values.", data: samples.distributionPaired, mapping: { group: "group", value: "value", subject: "subject", facet: "facet", pValue: "p_value" } },
     ],
   })),
-  ...(["pcoa", "umap"] as const).map((id) => ({
+  ...(["pcoa", "umap", "tsne", "nmds"] as const).map((id) => ({
     id,
-    name: id === "pcoa" ? "PCoA" : "UMAP",
+    name: id === "pcoa" ? "PCoA" : id === "umap" ? "UMAP" : id === "tsne" ? "t-SNE" : "NMDS",
     family: "Dimension reduction",
-    summary: id === "pcoa" ? "Publication-ready display of principal-coordinate scores from a distance analysis." : "Publication-ready display of a precomputed UMAP embedding.",
-    inputHint: id === "pcoa" ? "Upload PCoA coordinates produced from a documented distance metric. This plotter does not silently choose a distance." : "Upload precomputed UMAP coordinates; preserve the upstream seed and parameters in your analysis record.",
+    summary: id === "pcoa" ? "Publication-ready display of principal-coordinate scores from a documented distance analysis." : id === "umap" ? "Publication-ready display of a precomputed UMAP embedding." : id === "tsne" ? "Publication-ready display of a precomputed t-SNE embedding." : "Publication-ready display of precomputed non-metric multidimensional scaling coordinates.",
+    inputHint: id === "pcoa" ? "Upload precomputed PCoA coordinates and document the upstream distance metric; coordinates are never silently recomputed." : id === "umap" ? "Upload precomputed UMAP coordinates; preserve the upstream seed, neighbors, minimum distance, and metric in your analysis record." : id === "tsne" ? "Upload precomputed t-SNE coordinates; preserve the upstream seed, perplexity, metric, initialization, and iterations." : "Upload precomputed NMDS coordinates; preserve the dissimilarity, dimensions, starts, convergence, and stress.",
     roles: [
-      { key: "x", label: id === "pcoa" ? "PCoA axis 1" : "UMAP 1", kind: "number" as const, required: true },
-      { key: "y", label: id === "pcoa" ? "PCoA axis 2" : "UMAP 2", kind: "number" as const, required: true },
+      { key: "x", label: "Dimension 1", kind: "number" as const, required: true },
+      { key: "y", label: "Dimension 2", kind: "number" as const, required: true },
+      { key: "z", label: "Dimension 3 (3D only)", kind: "number" as const, required: false },
       { key: "group", label: "Group", kind: "category" as const, required: false },
+      { key: "shape", label: "Shape", kind: "category" as const, required: false },
       { key: "label", label: "Observation label", kind: "label" as const, required: false },
     ],
-    defaultMapping: { x: "dim1", y: "dim2", group: "group", label: "sample" },
-    sampleData: id === "pcoa" ? samples.pcoa : samples.umap,
+    defaultMapping: { x: "dim1", y: "dim2", z: "dim3", group: "group", shape: "shape", label: "sample" },
+    sampleData: samples[id],
+    examples: [
+      { label: "Example 1", description: "Precomputed two-dimensional coordinates with color groups, shapes, and labels.", data: samples[id], mapping: { x: "dim1", y: "dim2", z: "", group: "group", shape: "shape", label: "sample" } },
+      { label: "Example 2", description: "The same documented embedding with a supplied third coordinate for the optional 3D projection.", data: samples[id], mapping: { x: "dim1", y: "dim2", z: "dim3", group: "group", shape: "shape", label: "sample" } },
+    ],
   })),
   ...(["clustered-heatmap", "correlation-heatmap"] as const).map((id) => ({
     id,
@@ -1499,6 +1755,9 @@ export const plotReferences = {
   pca: { citation: "Jolliffe & Cadima, 2016. Principal component analysis: a review and recent developments. Phil Trans R Soc A.", href: "https://doi.org/10.1098/rsta.2015.0202" },
   pcoa: { citation: "Gower, 1966. Some distance properties of latent root and vector methods used in multivariate analysis. Biometrika.", href: "https://doi.org/10.1093/biomet/53.3-4.325" },
   umap: { citation: "McInnes et al., 2018. UMAP: Uniform Manifold Approximation and Projection. JOSS.", href: "https://doi.org/10.21105/joss.00861" },
+  tsne: { citation: "van der Maaten & Hinton, 2008. Visualizing Data using t-SNE. JMLR.", href: "https://doi.org/10.5555/1390156.1390177" },
+  nmds: { citation: "Kruskal, 1964. Nonmetric multidimensional scaling: a numerical method. Psychometrika.", href: "https://doi.org/10.1007/BF02289694" },
+  permanova: { citation: "Anderson, 2001. A new method for non-parametric multivariate analysis of variance. Austral Ecology.", href: "https://doi.org/10.1111/j.1442-9993.2001.01070.pp.x" },
   boxplot: { citation: "McGill, Tukey & Larsen, 1978. Variations of Box Plots. The American Statistician.", href: "https://doi.org/10.1080/00031305.1978.10479236" },
   violin: { citation: "Hintze & Nelson, 1998. Violin Plots: A Box Plot-Density Trace Synergism. The American Statistician.", href: "https://doi.org/10.1080/00031305.1998.10480559" },
   rawData: { citation: "Weissgerber et al., 2015. Beyond Bar and Line Graphs: Time for a New Data Presentation Paradigm. PLoS Biol.", href: "https://doi.org/10.1371/journal.pbio.1002128" },
@@ -1564,25 +1823,39 @@ const plotGuidanceSeeds: Record<PlotType, PlotGuidance> = {
     references: [plotReferences.anscombe, plotReferences.correlationTest, plotReferences.loess],
   },
   pca: {
-    definition: "一种线性无监督降维方法，把高维数据旋转到相互正交、按解释方差由高到低排列的主成分轴。",
-    suitableData: "高维特征×观察矩阵，如组学、影像特征、形态学、光谱、传感器或标准化临床特征。",
-    answers: "主要变异轴是什么，观察对象是否聚集、分离或存在离群点，以及分组或批次是否与总体结构相关。",
+    definition: "一种线性无监督降维方法，把高维数据旋转到相互正交、按解释方差由高到低排列的主成分轴；scores 表示观察对象，loadings 表示特征对各轴的贡献。",
+    suitableData: "高维特征×观察矩阵，如组学、影像特征、形态学、光谱、传感器或标准化临床特征。矩阵模式会透明记录过滤、变换、中心化与缩放。",
+    answers: "主要变异轴是什么，观察对象是否聚集、分离或存在离群点，哪些特征推动这些轴，以及分组或批次是否与总体结构相关。Scree 图用于判断方差在各主成分间如何分配。",
     origin: "Karl Pearson 于 1901 年提出空间点的最佳拟合直线与平面，Harold Hotelling 在 1933 年进一步建立并命名主成分分析。",
-    references: [plotReferences.pca],
+    references: [plotReferences.pca, plotReferences.permanova],
   },
   pcoa: {
     definition: "从样本间距离或相异度矩阵出发，通过特征分解构造低维坐标；它不是直接对原始特征矩阵做 PCA。",
     suitableData: "由明确距离或相异度度量得到的 PCoA 坐标，常见于生态、微生物群、组成或其他距离型数据。",
     answers: "在所选距离定义下，各观察对象的相似性结构和组间分离情况如何。",
     origin: "J. C. Gower 在 1966 年系统阐述了从距离关系恢复主坐标的数学性质，因此 PCoA 也常称为 Gower 主坐标分析。",
-    references: [plotReferences.pcoa],
+    references: [plotReferences.pcoa, plotReferences.permanova],
   },
   umap: {
     definition: "一种非线性流形学习方法，先构建高维邻域图，再寻找尽量保留局部邻域结构的低维嵌入。",
     suitableData: "高维数据上游计算得到的 UMAP 坐标，如单细胞、多组学、影像或表型特征。",
     answers: "局部邻域、亚群和异质性结构如何；不宜把远距离直接解释为定量差异。",
     origin: "McInnes 等人在 2018 年发布 UMAP，把黎曼几何与拓扑思想转化为可扩展的通用降维算法。",
-    references: [plotReferences.umap],
+    references: [plotReferences.umap, plotReferences.permanova],
+  },
+  tsne: {
+    definition: "t-SNE 以高维与低维邻域概率分布之间的差异为目标进行非线性嵌入；本模块只展示上游已计算坐标，不重新拟合。",
+    suitableData: "由记录了随机种子、perplexity、距离度量、初始化与迭代设置的 t-SNE 流程产生的样本或细胞坐标。",
+    answers: "局部邻域和潜在亚群在所给嵌入中如何组织。簇间距离、簇面积与全局方向通常没有直接定量含义。",
+    origin: "van der Maaten 与 Hinton 于 2008 年以重尾 Student t 分布缓解拥挤问题，形成今天广泛使用的 t-SNE。",
+    references: [plotReferences.tsne, plotReferences.permanova],
+  },
+  nmds: {
+    definition: "非度量多维尺度分析仅要求低维距离保持原始相异度的秩次关系，通过最小化 stress 得到配置；本模块展示预计算结果。",
+    suitableData: "由明确相异度（如 Bray–Curtis）和多次随机起点得到的 NMDS 坐标，并应同时记录维数、收敛状态与 stress。",
+    answers: "在相异度排序意义下样本结构、梯度和组间重叠如何；轴方向与绝对尺度本身通常没有固定含义。",
+    origin: "Kruskal 于 1964 年系统建立非度量多维尺度分析与 stress 优化框架，使秩次相异度能够映射到低维空间。",
+    references: [plotReferences.nmds, plotReferences.permanova],
   },
   box: {
     definition: "用中位数、上下四分位数、四分位距和按规则定义的“须”概括分布；须不一定代表最小值和最大值。",
@@ -1829,7 +2102,7 @@ const plotGuidanceSeeds: Record<PlotType, PlotGuidance> = {
 };
 
 const advancedRendererIds = new Set<PlotType>([
-  "line", "scatter", "correlation", "pcoa", "umap", "box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "ma", "quadrant", "errorbar", "area", "lollipop",
+  "line", "scatter", "correlation", "pca", "pcoa", "umap", "tsne", "nmds", "box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "ma", "quadrant", "errorbar", "area", "lollipop",
   "heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment-bar", "gsea", "km", "survival-forest", "roc", "venn",
   "upset", "sankey", "chord", "circos",
   "pie", "donut", "rose", "waffle", "treemap", "sunburst", "radar", "polar-profile", "population-pyramid",
@@ -1844,8 +2117,12 @@ const specializedSettingKeys: Partial<Record<PlotType, Array<keyof Visualization
   bar: ["swapAxes", "barErrorType", "barVariant", "barInputMode", "barOverlayType", "secondaryAxisLabel", "showSignificance", "significanceThreshold", "axisBreakStart", "axisBreakEnd", "barGap", "barBorderWidth", "barBorderColor", "errorBarLineWidth", "errorBarCapSize"],
   line: ["swapAxes", "showPoints", "lineErrorType", "lineUncertaintyStyle", "lineBandOpacity", "errorBarLineWidth", "errorBarCapSize"],
   scatter: ["swapAxes", "showLabels", "correlationMethod", "associationVariant", "associationFit", "associationPolynomialDegree", "associationLoessSpan", "associationShowConfidenceBand", "associationShowPValue", "associationGroupMode", "associationHexbinSize", "associationDensityBandwidth"],
-  correlation: ["showLabels", "correlationMethod", "associationVariant", "associationFit", "associationPolynomialDegree", "associationLoessSpan", "associationShowConfidenceBand", "associationShowPValue", "associationGroupMode", "associationHexbinSize", "associationDensityBandwidth"], pca: ["swapAxes", "showLabels"],
-  pcoa: ["showLabels"], umap: ["showLabels"],
+  correlation: ["showLabels", "correlationMethod", "associationVariant", "associationFit", "associationPolynomialDegree", "associationLoessSpan", "associationShowConfidenceBand", "associationShowPValue", "associationGroupMode", "associationHexbinSize", "associationDensityBandwidth"],
+  pca: ["swapAxes", "showLabels", "ordinationView", "ordinationShowEllipse", "ordinationShowHull", "ordinationShowCentroids", "ordinationShowLoadings", "ordinationLoadingCount", "ordinationUseShapes", "ordinationPermanovaR2", "ordinationPermanovaP", "ordinationPermanovaPermutations", "ordinationMethodNote"],
+  pcoa: ["showLabels", "ordinationView", "ordinationShowEllipse", "ordinationShowHull", "ordinationShowCentroids", "ordinationUseShapes", "ordinationXVariance", "ordinationYVariance", "ordinationZVariance", "ordinationPermanovaR2", "ordinationPermanovaP", "ordinationPermanovaPermutations", "ordinationMethodNote"],
+  umap: ["showLabels", "ordinationView", "ordinationShowEllipse", "ordinationShowHull", "ordinationShowCentroids", "ordinationUseShapes", "ordinationPermanovaR2", "ordinationPermanovaP", "ordinationPermanovaPermutations", "ordinationMethodNote"],
+  tsne: ["showLabels", "ordinationView", "ordinationShowEllipse", "ordinationShowHull", "ordinationShowCentroids", "ordinationUseShapes", "ordinationPermanovaR2", "ordinationPermanovaP", "ordinationPermanovaPermutations", "ordinationMethodNote"],
+  nmds: ["showLabels", "ordinationView", "ordinationShowEllipse", "ordinationShowHull", "ordinationShowCentroids", "ordinationUseShapes", "ordinationPermanovaR2", "ordinationPermanovaP", "ordinationPermanovaPermutations", "ordinationStress", "ordinationMethodNote"],
   box: ["showDensity", "showHistogram", "showBox", "showPoints", "showSampleSize", "distributionSummary", "boxErrorType", "distributionShowPairedLines", "distributionShowSignificance", "significanceThreshold", "distributionOrientation", "histogramBins", "violinBandwidth", "violinWidth", "errorBarLineWidth", "errorBarCapSize"],
   violin: ["showDensity", "showHistogram", "showBox", "showPoints", "showSampleSize", "distributionSummary", "boxErrorType", "distributionShowPairedLines", "distributionShowSignificance", "significanceThreshold", "distributionOrientation", "histogramBins", "violinBandwidth", "violinWidth", "errorBarLineWidth", "errorBarCapSize"],
   beeswarm: ["showDensity", "showHistogram", "showBox", "showPoints", "showSampleSize", "distributionSummary", "boxErrorType", "distributionShowPairedLines", "distributionShowSignificance", "significanceThreshold", "distributionOrientation", "histogramBins", "violinBandwidth", "violinWidth", "errorBarLineWidth", "errorBarCapSize"],
@@ -1881,7 +2158,7 @@ const newAxislessSettingKeys: Partial<Record<PlotType, ReadonlySet<keyof Visuali
 
 function dataShapeFor(type: PlotType): PlotDataShape {
   if (["heatmap", "clustered-heatmap", "correlation-heatmap", "pca"].includes(type)) return "matrix";
-  if (["pcoa", "umap"].includes(type)) return "coordinates";
+  if (["pcoa", "umap", "tsne", "nmds"].includes(type)) return "coordinates";
   if (["venn", "upset"].includes(type)) return "sets";
   if (["sankey", "chord"].includes(type)) return "network";
   if (["treemap", "sunburst"].includes(type)) return "hierarchy";
@@ -1898,17 +2175,22 @@ function numericAxesFor(type: PlotType): Array<"x" | "y"> {
   return ["x", "y"];
 }
 
-export function activeNumericAxes(type: PlotType, settings: Pick<VisualizationSettings, "swapAxes" | "barVariant" | "distributionOrientation" | "associationVariant">): Array<"x" | "y"> {
+export function activeNumericAxes(type: PlotType, settings: Pick<VisualizationSettings, "swapAxes" | "barVariant" | "distributionOrientation" | "associationVariant" | "ordinationView">): Array<"x" | "y"> {
   if (type === "bar") {
     if (settings.barVariant === "polar") return [];
     return settings.swapAxes || ["horizontal", "bullet", "pyramid"].includes(settings.barVariant) ? ["x"] : ["y"];
   }
   if (["box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge"].includes(type)) return settings.distributionOrientation === "horizontal" ? ["x"] : ["y"];
   if (["scatter", "correlation"].includes(type) && ["pair-matrix", "3d", "ternary"].includes(settings.associationVariant)) return [];
+  if (["pca", "pcoa", "umap", "tsne", "nmds"].includes(type) && settings.ordinationView !== "scores") return [];
   return numericAxesFor(type);
 }
 
 export function isPlotRoleActive(type: PlotType, roleKey: string, settings: VisualizationSettings) {
+  if (["pca", "pcoa", "umap", "tsne", "nmds"].includes(type)) {
+    if (settings.ordinationView === "scree") return false;
+    if (roleKey === "z") return settings.ordinationView === "3d";
+  }
   if (type !== "bar") return true;
   if (roleKey === "secondary") return ["dual-axis", "overlay"].includes(settings.barVariant);
   if (roleKey === "target") return settings.barVariant === "bullet";
@@ -2201,8 +2483,10 @@ const mappingAliases: Record<string, string[]> = {
   subject: ["subject", "subjectid", "pair", "pairid", "participant", "sampleid"],
   group: ["group", "class", "condition", "cluster", "ontology"],
   series: ["series", "group", "condition", "class"],
-  x: ["x", "time", "dose", "pc1", "dim1", "dimension1", "umap1"],
-  y: ["y", "response", "pc2", "dim2", "dimension2", "umap2"],
+  x: ["x", "time", "dose", "pc1", "dim1", "dimension1", "umap1", "tsne1", "nmds1"],
+  y: ["y", "response", "pc2", "dim2", "dimension2", "umap2", "tsne2", "nmds2"],
+  z: ["z", "pc3", "dim3", "dimension3", "umap3", "tsne3", "nmds3"],
+  shape: ["shape", "batch", "cohort", "site", "sex"],
   error: ["error", "sd", "sem", "se", "stderr", "standarddeviation", "standarderror"],
   label: ["label", "gene", "feature", "id", "name"],
   effect: ["log2fc", "logfc", "effect", "estimate"],
@@ -2421,6 +2705,113 @@ export function validatePlotDataset(
       if (blankCount > 0) errors.push(`${role.label} contains ${blankCount} blank value${blankCount === 1 ? "" : "s"}.`);
     }
   });
+
+  if (["pca", "pcoa", "umap", "tsne", "nmds"].includes(definition.id) && settings) {
+    const ordinationName = definition.name;
+    if (settings.ordinationView === "3d" && !mapping.z) errors.push(`${ordinationName} 3D projection requires a mapped third coordinate.`);
+    if (settings.ordinationView !== "scree") {
+      const coordinateColumns = [mapping.x, mapping.y, ...(settings.ordinationView === "3d" ? [mapping.z] : [])].filter(Boolean);
+      if (new Set(coordinateColumns).size !== coordinateColumns.length) errors.push("Every displayed ordination axis must map to a different coordinate column.");
+    }
+    if (settings.ordinationView === "scree") {
+      if (definition.id !== "pca") errors.push("Scree view is available only for PCA.");
+      if (!(dataset.analysis?.pca?.explainedVariance.length)) errors.push("PCA scree view requires explained-variance metadata from the matrix analysis.");
+    }
+
+    const scoreView = settings.ordinationView === "scores";
+    const threeDimensionalView = settings.ordinationView === "3d";
+    const groupedLayers = scoreView
+      ? settings.ordinationShowEllipse || settings.ordinationShowHull || settings.ordinationShowCentroids
+      : threeDimensionalView && settings.ordinationShowCentroids;
+    if (groupedLayers && !mapping.group) errors.push("Map a group column before displaying group ellipses, hulls, or centroids.");
+    if (scoreView && mapping.group && (settings.ordinationShowEllipse || settings.ordinationShowHull)) {
+      const groupedPoints = new Map<string, Array<{ x: number; y: number }>>();
+      dataset.rows.forEach((row) => {
+        const x = parseNumericValue(row[mapping.x]);
+        const y = parseNumericValue(row[mapping.y]);
+        if (x === null || y === null) return;
+        const group = row[mapping.group] || "All";
+        const points = groupedPoints.get(group) ?? [];
+        points.push({ x, y });
+        groupedPoints.set(group, points);
+      });
+      const undersized = [...groupedPoints].filter(([, points]) => points.length < 3).map(([group, points]) => `${group} (n=${points.length})`);
+      if (undersized.length > 0) errors.push(`${settings.ordinationShowEllipse ? "Covariance ellipses" : "Convex hulls"} require at least three observations per group; insufficient: ${undersized.join(", ")}.`);
+      if (settings.ordinationShowEllipse || settings.ordinationShowHull) {
+        const collinear = [...groupedPoints].filter(([, points]) => {
+          if (points.length < 3) return false;
+          const meanX = points.reduce((sum, point) => sum + point.x, 0) / points.length;
+          const meanY = points.reduce((sum, point) => sum + point.y, 0) / points.length;
+          const xx = points.reduce((sum, point) => sum + (point.x - meanX) ** 2, 0);
+          const yy = points.reduce((sum, point) => sum + (point.y - meanY) ** 2, 0);
+          const xy = points.reduce((sum, point) => sum + (point.x - meanX) * (point.y - meanY), 0);
+          return xx * yy - xy * xy <= 1e-12;
+        }).map(([group]) => group);
+        if (collinear.length > 0) errors.push(`${settings.ordinationShowEllipse && settings.ordinationShowHull ? "Covariance ellipses and convex hulls" : settings.ordinationShowEllipse ? "Covariance ellipses" : "Convex hulls"} require non-collinear coordinates; affected: ${collinear.join(", ")}.`);
+      }
+      if (settings.ordinationShowEllipse && [settings.xMin, settings.xMax, settings.yMin, settings.yMax].some((limit) => limit !== null)) {
+        const boundary = [...groupedPoints.values()].flatMap((points) => covarianceEllipsePoints(points.map((point) => definition.id === "pca" && settings.swapAxes ? { x: point.y, y: point.x } : point)));
+        const clipped = boundary.some((point) => (settings.xMin !== null && point.x < settings.xMin) || (settings.xMax !== null && point.x > settings.xMax) || (settings.yMin !== null && point.y < settings.yMin) || (settings.yMax !== null && point.y > settings.yMax));
+        if (clipped) warnings.push("Manual axis limits clip part of at least one ordination 95% covariance ellipse boundary.");
+      }
+    }
+
+    const pointView = scoreView || threeDimensionalView;
+    const displayedGroups = pointView && mapping.group ? dataset.rows.map((row) => row[mapping.group]?.trim()).filter(Boolean) : [];
+    const groupCount = new Set(displayedGroups).size;
+    if (pointView && mapping.group && displayedGroups.length !== dataset.rows.length) errors.push("Mapped ordination groups must not contain blank values.");
+    if (pointView && groupCount > 12 && settings.legendPosition !== "none") errors.push(`Ordination has ${groupCount} color groups, but the compact legend supports at most 12. Filter/facet the display or intentionally hide the legend.`);
+    if (pointView && groupCount > 12 && settings.legendPosition === "none") warnings.push(`${groupCount} groups use deterministic distinct colors with the legend intentionally hidden; preserve an external color key.`);
+    const shapeCount = pointView && settings.ordinationUseShapes && mapping.shape
+      ? new Set(dataset.rows.map((row) => row[mapping.shape]).filter(Boolean)).size
+      : 0;
+    if ((scoreView || threeDimensionalView) && settings.ordinationUseShapes && mapping.shape) {
+      if (shapeCount > 4) errors.push(`Mapped shape contains ${shapeCount} levels; the compact ordination view supports at most four distinct shapes.`);
+    }
+    if (pointView && settings.legendPosition !== "none" && !ordinationLegendLayout(definition.id as OrdinationType, settings, groupCount, shapeCount).fits) {
+      errors.push("The combined ordination color and shape legends do not fit inside the annotated compact canvas. Reduce group/shape levels, move or hide the legend, shorten annotations, or increase figure height.");
+    }
+    if (definition.id === "pca" && settings.ordinationShowLoadings && settings.ordinationView === "scores" && !(dataset.analysis?.pca?.loadings.length)) {
+      errors.push("PCA loading arrows require loading metadata from the matrix analysis.");
+    }
+    if (definition.id === "pca" && scoreView && settings.ordinationShowLoadings && [settings.xMin, settings.xMax, settings.yMin, settings.yMax].some((limit) => limit !== null)) {
+      const loadingLayout = ordinationLoadingLayout(dataset, mapping, settings);
+      if (loadingLayout.minimumArrowLength < 2) errors.push("PCA loading arrows require manual domains that include zero with enough room for every visible arrow and label in the final annotated plot. Use automatic or more balanced limits.");
+    }
+
+    const allPcoaVariances = [settings.ordinationXVariance, settings.ordinationYVariance, settings.ordinationZVariance];
+    const displayedPcoaIndexes = [mapping.x, mapping.y, ...(settings.ordinationView === "3d" ? [mapping.z] : [])].map((column, axisIndex) => {
+      const explicitAxis = column?.match(/(?:^|[_ .-])(?:dim|axis|component|pc|pcoa)[_ .-]?(\d+)$/i)?.[1];
+      return Math.max(0, Number(explicitAxis ?? axisIndex + 1) - 1);
+    });
+    const displayedPcoaVariances = displayedPcoaIndexes.map((index) => allPcoaVariances[index] ?? null);
+    if (definition.id === "pcoa" && allPcoaVariances.some((value) => value !== null)) {
+      if (displayedPcoaVariances.some((value) => value === null)) errors.push(`Supply explained variance for every displayed PCoA coordinate or leave all displayed values blank.`);
+      const numericVariances = allPcoaVariances.filter((value): value is number => value !== null);
+      if (numericVariances.some((value) => value < 0 || value > 100)) errors.push("PCoA explained-variance percentages must lie between 0 and 100.");
+      if (numericVariances.reduce((sum, value) => sum + value, 0) > 100.01) errors.push("Supplied PCoA explained-variance percentages cannot sum to more than 100%.");
+      const unusedSupplied = allPcoaVariances.flatMap((value, index) => value !== null && !displayedPcoaIndexes.includes(index) ? [`PCoA ${index + 1}`] : []);
+      if (unusedSupplied.length > 0) warnings.push(`Supplied variance for ${unusedSupplied.join(", ")} is preserved but not displayed in the current coordinate view.`);
+    }
+
+    const permanovaValues = [settings.ordinationPermanovaR2, settings.ordinationPermanovaP, settings.ordinationPermanovaPermutations];
+    if (settings.ordinationView !== "scree" && permanovaValues.some((value) => value !== null)) {
+      if (permanovaValues.some((value) => value === null)) errors.push("Supplied PERMANOVA requires R², P value, and permutation count together.");
+      if (!mapping.group) errors.push("Map the tested group column before displaying supplied PERMANOVA results.");
+      if (mapping.group && groupCount < 2) errors.push("Supplied PERMANOVA requires at least two non-empty levels in the mapped tested-group column.");
+      if (settings.ordinationMethodNote.trim().length < 12) errors.push("Supplied PERMANOVA requires a method note identifying the distance, tested formula/factor, and any strata or permutation constraints.");
+      if (settings.ordinationPermanovaR2 !== null && (settings.ordinationPermanovaR2 < 0 || settings.ordinationPermanovaR2 > 1)) errors.push("PERMANOVA R² must lie between 0 and 1.");
+      if (settings.ordinationPermanovaP !== null && (settings.ordinationPermanovaP <= 0 || settings.ordinationPermanovaP > 1)) errors.push("PERMANOVA P value must lie in (0, 1].");
+      if (settings.ordinationPermanovaPermutations !== null && (!Number.isInteger(settings.ordinationPermanovaPermutations) || settings.ordinationPermanovaPermutations < 1)) errors.push("PERMANOVA permutations must be a positive integer.");
+      warnings.push("PERMANOVA values are displayed as supplied; Visualization Studio does not recompute them from ordination coordinates. Confirm that the mapped display group matches the tested model factor.");
+    }
+    if (definition.id === "nmds" && settings.ordinationStress !== null) {
+      if (settings.ordinationStress < 0) errors.push("NMDS stress must be non-negative.");
+      if (settings.ordinationMethodNote.trim().length < 12) errors.push("Supplied NMDS stress requires a method note identifying the stress definition, dissimilarity, dimensionality, and convergence information.");
+    }
+    if (settings.ordinationMethodNote.trim().length > 72) warnings.push("The upstream method note is truncated to 72 characters in the compact figure; preserve the full method in the caption or analysis record.");
+    if (dataset.rows.length > 5_000) warnings.push(`${ordinationName} contains ${dataset.rows.length.toLocaleString()} observations; consider rasterization or stratified downsampling for a legible compact export.`);
+  }
 
   if (["volcano", "ma", "enrichment", "enrichment-bar"].includes(definition.id) && mapping.pValue) {
     const pColumn = mapping.pValue;
@@ -3193,10 +3584,10 @@ export function axisLimitWarning(
   });
   let xValues: number[] = [];
   let yValues: number[] = [];
-  if (["scatter", "correlation", "pca", "pcoa", "umap", "quadrant"].includes(definition.id)) {
+  if (["scatter", "correlation", "pca", "pcoa", "umap", "tsne", "nmds", "quadrant"].includes(definition.id)) {
     xValues = valuesAt("x");
     yValues = valuesAt("y");
-    if (["scatter", "correlation"].includes(definition.id) && settings.swapAxes) [xValues, yValues] = [yValues, xValues];
+    if (["scatter", "correlation", "pca"].includes(definition.id) && settings.swapAxes) [xValues, yValues] = [yValues, xValues];
     if (definition.id === "quadrant") {
       xValues.push(settings.xThreshold);
       yValues.push(settings.yThreshold);

--- a/tests/e2e/visualization-studio.spec.ts
+++ b/tests/e2e/visualization-studio.spec.ts
@@ -210,6 +210,142 @@ test.describe("Visualization Studio browser acceptance", () => {
     expect(escapedGeometry).toEqual([]);
   });
 
+  test("configures reproducible ordination views without recomputing supplied coordinates", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop-chromium", "Desktop ordination controls");
+    await page.goto("/");
+    await page.getByRole("button", { name: /^PCA/ }).click();
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "PCA observation metadata" })).toHaveValue(/Control_1\tControl\tBatch 1\tC1/);
+    await expect(page.getByRole("combobox", { name: "Shape" })).toHaveValue("batch");
+    const pcaSvg = page.locator("svg[aria-label='PCA scientific figure preview']");
+    await expect(pcaSvg).toHaveAttribute("data-plot-renderer", "advanced");
+    await expect(pcaSvg.locator("[data-plot-element='ordination-shape-legend']")).toBeVisible();
+    await page.getByRole("checkbox", { name: "Group covariance ellipses" }).check({ force: true });
+    await page.getByRole("checkbox", { name: "Group centroids" }).check({ force: true });
+    await page.getByRole("checkbox", { name: "Feature loading arrows" }).check({ force: true });
+    await page.getByRole("checkbox", { name: "Point labels" }).check({ force: true });
+    await expect(pcaSvg.locator("[data-plot-element='ordination-ellipse']")).toHaveCount(2);
+    await expect(pcaSvg.locator("[data-plot-element='ordination-centroid']")).toHaveCount(2);
+    await expect(pcaSvg.locator("[data-plot-element='ordination-loading']").first()).toBeVisible();
+    await expect(pcaSvg).toContainText(/PC1 \([\d.]+%\)/);
+    const clippedPcaLabels = await pcaSvg.evaluate((element) => {
+      const svg = element as SVGSVGElement;
+      const canvas = svg.getBoundingClientRect();
+      const clip = svg.querySelector("clipPath rect")!;
+      const scaleX = canvas.width / svg.viewBox.baseVal.width;
+      const scaleY = canvas.height / svg.viewBox.baseVal.height;
+      const plot = { left: canvas.left + Number(clip.getAttribute("x")) * scaleX, top: canvas.top + Number(clip.getAttribute("y")) * scaleY, right: canvas.left + (Number(clip.getAttribute("x")) + Number(clip.getAttribute("width"))) * scaleX, bottom: canvas.top + (Number(clip.getAttribute("y")) + Number(clip.getAttribute("height"))) * scaleY };
+      return [...element.querySelectorAll("[data-plot-label]")].flatMap((label) => {
+        const box = label.getBoundingClientRect();
+        return box.left < plot.left - 1 || box.top < plot.top - 1 || box.right > plot.right + 1 || box.bottom > plot.bottom + 1 ? [label.textContent] : [];
+      });
+    });
+    expect(clippedPcaLabels).toEqual([]);
+    await page.getByRole("textbox", { name: "Method note", exact: true }).fill("Euclidean distance; group tested with cohort strata and restricted permutations");
+    for (const [label, value] of [["R²", "0.21"], ["P value", "0.012"], ["Permutations", "999"]] as const) {
+      await page.getByRole("textbox", { name: label, exact: true }).fill(value);
+      await page.getByRole("textbox", { name: label, exact: true }).press("Enter");
+    }
+    await expect(pcaSvg).toContainText("PERMANOVA (supplied)");
+    await page.getByRole("textbox", { name: "Y minimum", exact: true }).fill("-0.001");
+    await page.getByRole("textbox", { name: "Y minimum", exact: true }).press("Enter");
+    await expect(page.getByText(/loading arrows require manual domains/)).toBeVisible();
+    await page.getByRole("textbox", { name: "Y minimum", exact: true }).fill("");
+    await page.getByRole("textbox", { name: "Y minimum", exact: true }).press("Enter");
+    for (const [label, value] of [["X minimum", "-0.1"], ["X maximum", "10"]] as const) {
+      await page.getByRole("textbox", { name: label, exact: true }).fill(value);
+      await page.getByRole("textbox", { name: label, exact: true }).press("Enter");
+    }
+    await expect(page.getByText(/loading arrows require manual domains/)).toBeVisible();
+    await expect(page.getByRole("button", { name: "SVG" })).toBeDisabled();
+    for (const [label, value] of [["X minimum", "-4"], ["X maximum", "6"]] as const) {
+      await page.getByRole("textbox", { name: label, exact: true }).fill(value);
+      await page.getByRole("textbox", { name: label, exact: true }).press("Enter");
+    }
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const unsafeLoadings = await pcaSvg.evaluate((element) => {
+      const svg = element as SVGSVGElement;
+      const canvas = svg.getBoundingClientRect();
+      const clip = svg.querySelector("clipPath rect")!;
+      const scaleX = canvas.width / svg.viewBox.baseVal.width;
+      const scaleY = canvas.height / svg.viewBox.baseVal.height;
+      const plot = { left: canvas.left + Number(clip.getAttribute("x")) * scaleX, top: canvas.top + Number(clip.getAttribute("y")) * scaleY, right: canvas.left + (Number(clip.getAttribute("x")) + Number(clip.getAttribute("width"))) * scaleX, bottom: canvas.top + (Number(clip.getAttribute("y")) + Number(clip.getAttribute("height"))) * scaleY };
+      return [...svg.querySelectorAll("[data-plot-element='ordination-loading']")].flatMap((loading) => {
+        const label = loading.querySelector("text")?.getBoundingClientRect();
+        const line = loading.querySelector("line");
+        const length = line ? Math.hypot(Number(line.getAttribute("x2")) - Number(line.getAttribute("x1")), Number(line.getAttribute("y2")) - Number(line.getAttribute("y1"))) : 0;
+        const labelInside = label && label.left >= plot.left - 1 && label.top >= plot.top - 1 && label.right <= plot.right + 1 && label.bottom <= plot.bottom + 1;
+        return length >= 2 && labelInside ? [] : [{ label: loading.textContent, length, scale: loading.getAttribute("data-loading-scale") }];
+      });
+    });
+    expect(unsafeLoadings).toEqual([]);
+
+    await page.getByRole("combobox", { name: "View" }).selectOption("scree");
+    await expect(page.getByText("Supplied PERMANOVA", { exact: true })).toHaveCount(0);
+    await expect(page.getByRole("checkbox", { name: "Group covariance ellipses" })).toHaveCount(0);
+    await expect(pcaSvg.locator("[data-plot-family='ordination-scree']")).toBeVisible();
+    await expect(pcaSvg.locator("[data-plot-element='scree-bar']").first()).toBeVisible();
+    await expect(pcaSvg).toContainText("Principal component");
+    await expect(pcaSvg).toContainText("Explained variance (%)");
+    await page.getByRole("combobox", { name: "View" }).selectOption("3d");
+    await expect(page.getByRole("combobox", { name: "Z component" })).toHaveValue("PC3");
+    await expect(pcaSvg.locator("[data-plot-family='ordination-3d']")).toBeVisible();
+    await expect(pcaSvg.locator("[data-plot-element='ordination-shape-legend']")).toBeVisible();
+
+    await page.getByRole("button", { name: /^PCoA/ }).click();
+    await page.getByRole("button", { name: "Example 2" }).click();
+    await page.getByRole("combobox", { name: "View" }).selectOption("3d");
+    for (const [label, value] of [["PCoA 1 variance (%)", "41.2"], ["PCoA 2 variance (%)", "22.4"], ["PCoA 3 variance (%)", "11.3"], ["R²", "0.183"], ["P value", "0.004"], ["Permutations", "999"]] as const) {
+      await page.getByRole("textbox", { name: label, exact: true }).fill(value);
+      await page.getByRole("textbox", { name: label, exact: true }).press("Enter");
+    }
+    await page.getByRole("textbox", { name: "Method note" }).fill("Bray-Curtis; blocked permutations by cohort");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const pcoaSvg = page.locator("svg[aria-label='PCoA scientific figure preview']");
+    await expect(pcoaSvg).toContainText("PERMANOVA (supplied)");
+    await expect(pcoaSvg).toContainText("PCoA 3 (11.3%)");
+    const escapedText = await pcoaSvg.evaluate((element) => {
+      const canvas = element.getBoundingClientRect();
+      return [...element.querySelectorAll("text")].flatMap((label) => {
+        const box = label.getBoundingClientRect();
+        return box.left < canvas.left - 1 || box.top < canvas.top - 1 || box.right > canvas.right + 1 || box.bottom > canvas.bottom + 1 ? [label.textContent] : [];
+      });
+    });
+    expect(escapedText).toEqual([]);
+
+    for (const name of ["t-SNE", "NMDS"]) {
+      await page.getByRole("button", { name: new RegExp(`^${name}`) }).click();
+      await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+      await expect(page.locator(`svg[aria-label='${name} scientific figure preview'] [data-plot-family='ordination-scores']`)).toBeVisible();
+    }
+  });
+
+  test("blocks crowded combined ordination legends until the export canvas can contain them", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop-chromium", "Desktop ordination legend boundary");
+    await page.goto("/");
+    await page.getByRole("button", { name: /^PCoA/ }).click();
+    const crowdedRows = Array.from({ length: 12 }, (_, index) => `${index}\t${index % 3}\tExtremelyWideGroupName${index + 1}\tShape${index % 4 + 1}\tS${index + 1}`);
+    await page.getByRole("textbox", { name: "CSV or TSV data" }).fill(`dim1\tdim2\tgroup\tshape\tsample\n${crowdedRows.join("\n")}`);
+    await expect(page.getByRole("combobox", { name: "Group" })).toHaveValue("group");
+    await expect(page.getByRole("combobox", { name: "Shape" })).toHaveValue("shape");
+    await page.getByRole("textbox", { name: "Method note" }).fill("Long upstream annotation describing distance transformation normalization and reproducible coordinate generation");
+    await expect(page.getByText(/combined ordination color and shape legends/)).toBeVisible();
+    await expect(page.getByRole("button", { name: "SVG" })).toBeDisabled();
+    await page.getByRole("textbox", { name: "Height value" }).fill("640");
+    await page.getByRole("textbox", { name: "Height value" }).press("Enter");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const pcoaSvg = page.locator("svg[aria-label='PCoA scientific figure preview']");
+    const escapedLegendText = await pcoaSvg.evaluate((element) => {
+      const canvas = element.getBoundingClientRect();
+      return [...element.querySelectorAll("[data-plot-element='plot-legend'] text, [data-plot-element='ordination-shape-legend'] text")].flatMap((label) => {
+        const box = label.getBoundingClientRect();
+        return box.left < canvas.left - 1 || box.top < canvas.top - 1 || box.right > canvas.right + 1 || box.bottom > canvas.bottom + 1 ? [label.textContent] : [];
+      });
+    });
+    expect(escapedLegendText).toEqual([]);
+    await expect(pcoaSvg.locator("[data-plot-element='plot-legend'] text[data-full-label^='ExtremelyWideGroupName']").first()).toContainText("…");
+  });
+
   test("switches categorical variants and computes long-form uncertainty", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "desktop-chromium", "Desktop categorical-family baseline");
     await page.goto("/");


### PR DESCRIPTION
Closes #10

## Summary
- add t-SNE and NMDS to the registry and unify PCA, PCoA, UMAP, t-SNE, and NMDS score/3D rendering
- add deterministic browser-local PCA with exact sample-metadata joins, scree plots, loadings, ellipses, hulls, centroids, shapes, supplied variance/stress/PERMANOVA metadata, and method disclosure
- preserve precomputed coordinates without recomputation and add conservative validation for feature limits, legends, labels, manual domains, and compact-canvas geometry
- share ordination frame/domain/loading/legend calculations between validation and SVG rendering
- add adaptive long-label truncation with full labels retained in SVG titles/data attributes

## Verification
- 88 unit/rendering tests passed
- TypeScript typecheck passed
- ESLint passed
- 12 Playwright browser tests passed (6 intentional device skips)
- Next.js production build passed with webpack
- independent specification review: Clean
- independent scientific/engineering review: Clean