### PR TITLE
feat: upgrade Venn and UpSet set-intersection workflows

### DIFF
--- a/src/components/ScientificAdvancedChartPreview.tsx
+++ b/src/components/ScientificAdvancedChartPreview.tsx
@@ -4,10 +4,10 @@ import type { ReactNode, RefObject } from "react";
 import { ScientificGenomicPlot, isGenomicPlotType } from "@/components/ScientificGenomicChartPreview";
 import { ScientificRelationshipPlot, isRelationshipPlotType } from "@/components/ScientificNetworkChartPreview";
 import { ScientificFlowCircularPlot } from "@/components/ScientificFlowCircularChartPreview";
+import { ScientificSetPlot } from "@/components/ScientificSetChartPreview";
 import { genomicFrameMetrics } from "@/lib/visualization-genomics";
 import { networkFrameMetrics } from "@/lib/visualization-network";
 import {
-  buildSetMemberships,
   correlation,
   correlationPValue,
   correlationMatrix,
@@ -16,8 +16,6 @@ import {
   kaplanMeier,
   matrixFromRows,
   rocCurve,
-  upsetVerticalLayout,
-  vennRegionLayout,
   type HierarchicalClusterNode,
 } from "@/lib/visualization-advanced";
 import {
@@ -857,35 +855,6 @@ function RocPlot({ frame, dataset, mapping, settings, colors, gridColor }: { fra
   </>;
 }
 
-function VennPlot({ frame, dataset, mapping, settings, colors }: { frame: Frame; dataset: ParsedDataset; mapping: Record<string, string>; settings: VisualizationSettings; colors: string[] }) {
-  const membership = buildSetMemberships(dataset.rows, mapping.item, mapping.set);
-  const sets = membership.sets;
-  const centers = sets.length === 2 ? [[frame.left + frame.plotWidth * 0.43, frame.top + frame.plotHeight * 0.52], [frame.left + frame.plotWidth * 0.57, frame.top + frame.plotHeight * 0.52]] : [[frame.left + frame.plotWidth * 0.43, frame.top + frame.plotHeight * 0.43], [frame.left + frame.plotWidth * 0.57, frame.top + frame.plotHeight * 0.43], [frame.left + frame.plotWidth * 0.5, frame.top + frame.plotHeight * 0.59]];
-  const radius = Math.min(frame.plotWidth, frame.plotHeight) * 0.27;
-  const layout = vennRegionLayout(centers as Array<[number, number]>, radius);
-  const exact = (wanted: string[]) => [...membership.memberships.values()].filter((itemSets) => itemSets.size === wanted.length && wanted.every((set) => itemSets.has(set))).length;
-  return <g>
-    {sets.map((set, index) => <g key={set}><circle cx={centers[index][0]} cy={centers[index][1]} r={radius} fill={colors[index % colors.length]} fillOpacity={settings.opacity * 0.3} stroke={colors[index % colors.length]} strokeWidth={settings.dataLineWidth} /><text x={layout.setLabels[index][0]} y={layout.setLabels[index][1]} textAnchor="middle" fill={TEXT} fontSize={settings.legendSize} fontWeight={700}>{set}</text></g>)}
-    {sets.map((set, index) => <text key={`only-${set}`} x={layout.only[index][0]} y={layout.only[index][1]} textAnchor="middle" fill={TEXT} fontSize={settings.axisLabelSize} fontWeight={700}>{exact([set])}</text>)}
-    {sets.length >= 2 ? <text x={layout.pairs[0][0]} y={layout.pairs[0][1]} textAnchor="middle" fill={TEXT} fontSize={settings.axisLabelSize} fontWeight={700}>{exact([sets[0], sets[1]])}</text> : null}
-    {sets.length === 3 && layout.triple ? <><text x={layout.pairs[1][0]} y={layout.pairs[1][1]} textAnchor="middle" fill={TEXT} fontSize={settings.tickSize} fontWeight={700}>{exact([sets[0], sets[2]])}</text><text x={layout.pairs[2][0]} y={layout.pairs[2][1]} textAnchor="middle" fill={TEXT} fontSize={settings.tickSize} fontWeight={700}>{exact([sets[1], sets[2]])}</text><text x={layout.triple[0]} y={layout.triple[1]} textAnchor="middle" fill={TEXT} fontSize={settings.axisLabelSize} fontWeight={700}>{exact(sets)}</text></> : null}
-  </g>;
-}
-
-function UpSetPlot({ frame, dataset, mapping, settings, colors }: { frame: Frame; dataset: ParsedDataset; mapping: Record<string, string>; settings: VisualizationSettings; colors: string[] }) {
-  const membership = buildSetMemberships(dataset.rows, mapping.item, mapping.set);
-  const intersections = membership.intersections.slice(0, Math.min(10, Math.floor(frame.plotWidth / 38)));
-  const max = Math.max(...intersections.map((entry) => entry.size), 1);
-  const layout = upsetVerticalLayout(frame.top, frame.plotHeight, membership.sets.length);
-  const band = frame.plotWidth / Math.max(1, intersections.length);
-  return <g>
-    <line x1={frame.left} x2={frame.left + frame.plotWidth} y1={layout.baseline} y2={layout.baseline} stroke={TEXT} strokeWidth={settings.axisLineWidth} />
-    {intersections.map((entry, index) => { const height = entry.size / max * layout.barHeight; const x = frame.left + band * (index + 0.5); return <g key={entry.sets.join("|")}><rect x={x - band * 0.28} y={layout.baseline - height} width={band * 0.56} height={height} fill={colors[0]} fillOpacity={settings.opacity} /><text x={x} y={layout.baseline - height - 7} textAnchor="middle" fill={TEXT} fontSize={settings.tickSize}>{entry.size}</text>{membership.sets.map((set, setIndex) => <circle key={set} cx={x} cy={layout.matrixTop + setIndex * layout.rowGap} r={4.5} fill={entry.sets.includes(set) ? colors[1] ?? colors[0] : "#D5D6D8"} />)}{entry.sets.length > 1 ? <line x1={x} x2={x} y1={layout.matrixTop + Math.min(...entry.sets.map((set) => membership.sets.indexOf(set))) * layout.rowGap} y2={layout.matrixTop + Math.max(...entry.sets.map((set) => membership.sets.indexOf(set))) * layout.rowGap} stroke={colors[1] ?? colors[0]} strokeWidth={2} /> : null}</g>; })}
-    {membership.sets.map((set, index) => <text key={set} x={frame.left - 8} y={layout.matrixTop + index * layout.rowGap + settings.tickSize * 0.34} textAnchor="end" fill={TEXT} fontSize={settings.tickSize}>{set.slice(0, 16)}</text>)}
-    <text x={frame.left} y={frame.top + settings.axisLabelSize} fill={TEXT} fontSize={settings.axisLabelSize} fontWeight={700}>Intersection size</text>
-  </g>;
-}
-
 function SankeyPlot({ frame, dataset, mapping, settings, colors }: { frame: Frame; dataset: ParsedDataset; mapping: Record<string, string>; settings: VisualizationSettings; colors: string[] }) {
   return <ScientificFlowCircularPlot type="sankey" frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} />;
 }
@@ -1067,8 +1036,7 @@ export function ScientificAdvancedChartPreview({ svgRef, type, dataset, mapping,
   else if (type === "km") content = <KmPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (type === "survival-forest") content = <ForestPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (type === "roc") content = <RocPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
-  else if (type === "venn") content = <VennPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} />;
-  else if (type === "upset") content = <UpSetPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} />;
+  else if (type === "venn" || type === "upset") content = <ScientificSetPlot type={type} frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} />;
   else if (type === "sankey") content = <SankeyPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} />;
   else if (type === "alluvial") content = <ScientificFlowCircularPlot type="alluvial" frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} />;
   else if (type === "chord") content = <ChordPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} />;

--- a/src/components/ScientificSetChartPreview.tsx
+++ b/src/components/ScientificSetChartPreview.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import {
+  analyzeSetIntersections,
+  radialIntersectionLayout,
+  exactIntersectionCount,
+  upsetAdaptiveLayout,
+} from "@/lib/visualization-sets";
+import {
+  categoricalColorForIndex,
+  type ParsedDataset,
+  type VisualizationSettings,
+} from "@/lib/visualization-studio";
+
+type Frame = { width: number; height: number; left: number; right: number; top: number; bottom: number; plotWidth: number; plotHeight: number };
+type Props = { type: "venn" | "upset"; frame: Frame; dataset: ParsedDataset; mapping: Record<string, string>; settings: VisualizationSettings; colors: string[] };
+const TEXT = "#23242A";
+
+function polar(cx: number, cy: number, radius: number, angle: number) { return [cx + Math.cos(angle) * radius, cy + Math.sin(angle) * radius] as const; }
+function sectorPath(cx: number, cy: number, inner: number, outer: number, start: number, end: number) {
+  const a = polar(cx, cy, outer, start); const b = polar(cx, cy, outer, end); const c = polar(cx, cy, inner, end); const d = polar(cx, cy, inner, start); const large = end - start > Math.PI ? 1 : 0;
+  return `M ${a[0]} ${a[1]} A ${outer} ${outer} 0 ${large} 1 ${b[0]} ${b[1]} L ${c[0]} ${c[1]} A ${inner} ${inner} 0 ${large} 0 ${d[0]} ${d[1]} Z`;
+}
+function arcPath(cx: number, cy: number, radius: number, start: number, end: number) { const a = polar(cx, cy, radius, start); const b = polar(cx, cy, radius, end); return `M ${a[0]} ${a[1]} A ${radius} ${radius} 0 ${end - start > Math.PI ? 1 : 0} 1 ${b[0]} ${b[1]}`; }
+
+function RegionLabel({ x, y, count, signature, fontSize }: { x: number; y: number; count: number; signature: string; fontSize: number }) {
+  return <text data-plot-label data-plot-element="set-region-label" data-intersection-signature={signature} x={x} y={y + fontSize * 0.34} textAnchor="middle" fill={TEXT} fontSize={fontSize} fontWeight={700}>{count}<title>{`${signature.split("\u0001").join(" ∩ ")}: ${count}`}</title></text>;
+}
+
+function SetLegend({ sets, frame, settings, colors }: { sets: string[]; frame: Frame; settings: VisualizationSettings; colors: string[] }) {
+  const columns = Math.min(4, sets.length); const cellWidth = frame.width / Math.max(1, columns);
+  const fontSize = Math.max(7, settings.tickSize - 2); const labelCapacity = Math.max(2, Math.floor((cellWidth - 20) / (fontSize * 0.58)));
+  return <g data-no-clip="true" data-plot-element="set-legend">{sets.map((set, index) => { const x = 8 + (index % columns) * cellWidth; const y = frame.top + frame.plotHeight + 14 + Math.floor(index / columns) * 13; const visible = set.length > labelCapacity ? `${set.slice(0, Math.max(1, labelCapacity - 1))}…` : set; return <g key={set}><rect data-no-clip="true" x={x} y={y - 8} width={7} height={7} rx={1} fill={categoricalColorForIndex(index, colors)} /><text data-no-clip="true" data-full-label={set} x={x + 10} y={y - 1} fill={TEXT} fontSize={fontSize}>{visible}<title>{set}</title></text></g>; })}</g>;
+}
+
+function ClassicVenn({ frame, analysis, settings, colors }: { frame: Frame; analysis: ReturnType<typeof analyzeSetIntersections>; settings: VisualizationSettings; colors: string[] }) {
+  const sets = analysis.sets; const baseRadius = Math.min(frame.plotWidth, frame.plotHeight) * (sets.length === 2 ? 0.29 : 0.255); const cx = frame.left + frame.plotWidth / 2; const cy = frame.top + frame.plotHeight * 0.49;
+  const centers: Array<[number, number]> = sets.length === 2 ? [[cx - baseRadius * 0.42, cy], [cx + baseRadius * 0.42, cy]] : [[cx - baseRadius * 0.43, cy - baseRadius * 0.23], [cx + baseRadius * 0.43, cy - baseRadius * 0.23], [cx, cy + baseRadius * 0.48]];
+  const maxSetSize = Math.max(...sets.map((set) => analysis.setSizes.get(set) ?? 0), 1);
+  const radii = sets.map((set) => settings.vennProportional ? baseRadius * (0.66 + 0.34 * Math.sqrt((analysis.setSizes.get(set) ?? 0) / maxSetSize)) : baseRadius);
+  const labels = sets.length === 2 ? [
+    { wanted: [sets[0]], x: centers[0][0] - baseRadius * 0.54, y: cy },
+    { wanted: [sets[1]], x: centers[1][0] + baseRadius * 0.54, y: cy },
+    { wanted: sets, x: cx, y: cy },
+  ] : [
+    { wanted: [sets[0]], x: centers[0][0] - baseRadius * 0.55, y: centers[0][1] },
+    { wanted: [sets[1]], x: centers[1][0] + baseRadius * 0.55, y: centers[1][1] },
+    { wanted: [sets[2]], x: cx, y: centers[2][1] + baseRadius * 0.54 },
+    { wanted: [sets[0], sets[1]], x: cx, y: cy - baseRadius * 0.53 },
+    { wanted: [sets[0], sets[2]], x: cx - baseRadius * 0.35, y: cy + baseRadius * 0.21 },
+    { wanted: [sets[1], sets[2]], x: cx + baseRadius * 0.35, y: cy + baseRadius * 0.21 },
+    { wanted: sets, x: cx, y: cy + baseRadius * 0.02 },
+  ];
+  const setLabelPositions: Array<[number, number]> = sets.length === 2 ? [[cx - baseRadius * 1.08, cy - baseRadius * 0.92], [cx + baseRadius * 1.08, cy - baseRadius * 0.92]] : [[cx - baseRadius * 1.13, cy - baseRadius * 0.83], [cx + baseRadius * 1.13, cy - baseRadius * 0.83], [cx, cy + baseRadius * 1.48]];
+  const labelCapacity = Math.max(3, Math.floor(baseRadius * 1.5 / (settings.tickSize * 0.58)));
+  return <g data-plot-data data-plot-family="venn-classic" data-input-mode={analysis.mode} data-size-weighting={settings.vennProportional ? "set-size-radius-cue" : "none"}>
+    {sets.map((set, index) => { const visible = set.length > labelCapacity ? `${set.slice(0, Math.max(2, labelCapacity - 1))}…` : set; return <g key={set}><circle data-plot-element="venn-set" data-set={set} cx={centers[index][0]} cy={centers[index][1]} r={radii[index]} fill={categoricalColorForIndex(index, colors)} fillOpacity={settings.opacity * 0.24} stroke={categoricalColorForIndex(index, colors)} strokeWidth={settings.dataLineWidth} /><text data-plot-label data-full-label={set} x={setLabelPositions[index][0]} y={setLabelPositions[index][1]} textAnchor="middle" fill={TEXT} fontSize={settings.tickSize} fontWeight={700}>{visible}<title>{set}</title></text></g>; })}
+    {labels.map((entry) => { const signature = sets.filter((set) => entry.wanted.includes(set)).join("\u0001"); return <RegionLabel key={signature} x={entry.x} y={entry.y} count={exactIntersectionCount(analysis, entry.wanted)} signature={signature} fontSize={settings.axisLabelSize} />; })}
+    {settings.vennProportional ? <text data-plot-label x={frame.left} y={frame.top + frame.plotHeight - 5} fill={TEXT} fontSize={Math.max(7, settings.tickSize - 3)}>Radius is a set-size cue, not an area-proportional fit; region counts are exact.</text> : null}
+  </g>;
+}
+
+function RadialIntersections({ frame, analysis, settings, colors }: { frame: Frame; analysis: ReturnType<typeof analyzeSetIntersections>; settings: VisualizationSettings; colors: string[] }) {
+  const cx = frame.left + frame.plotWidth / 2; const cy = frame.top + frame.plotHeight * 0.48; const radius = Math.min(frame.plotWidth, frame.plotHeight) * 0.31; const inner = radius * 0.28;
+  const regions = radialIntersectionLayout(analysis, -Math.PI / 2, settings.vennProportional); const maximum = Math.max(...regions.map((region) => region.size), 1);
+  return <g data-plot-data data-plot-family="venn-radial" data-input-mode={analysis.mode} data-layout="radial-exact-intersections" data-size-weighting={settings.vennProportional ? "intersection-angle" : "none"}>
+    {regions.map((region) => { const label = polar(cx, cy, inner + (radius - inner) * 0.56, region.middle); const primarySet = analysis.sets.findIndex((set) => region.sets.includes(set)); return <g key={region.signature}><path data-plot-element="radial-intersection-region" data-intersection-signature={region.signature} data-intersection-size={region.size} d={sectorPath(cx, cy, inner, radius, region.start, region.end)} fill={categoricalColorForIndex(Math.max(0, primarySet), colors)} fillOpacity={settings.opacity * (0.16 + 0.24 * region.size / maximum)} stroke="#FFFFFF" strokeWidth={0.8}><title>{`${region.sets.join(" ∩ ")}: ${region.size}`}</title></path><RegionLabel x={label[0]} y={label[1]} count={region.size} signature={region.signature} fontSize={Math.max(7, settings.tickSize - (regions.length > 14 ? 3 : 1))} />{region.sets.map((set) => { const setIndex = analysis.sets.indexOf(set); return <path key={set} data-plot-element="radial-membership-arc" data-set={set} d={arcPath(cx, cy, radius + 4 + setIndex * 3, region.start, region.end)} fill="none" stroke={categoricalColorForIndex(setIndex, colors)} strokeWidth={2} />; })}</g>; })}
+    <circle cx={cx} cy={cy} r={inner - 3} fill="#FFFFFF" stroke="#DDD9D2" /><text x={cx} y={cy - 2} textAnchor="middle" fill={TEXT} fontSize={settings.tickSize} fontWeight={700}>Radial</text><text x={cx} y={cy + 10} textAnchor="middle" fill={TEXT} fontSize={Math.max(7, settings.tickSize - 3)}>{regions.length} observed exact regions</text>
+    <SetLegend sets={analysis.sets} frame={frame} settings={settings} colors={colors} />
+  </g>;
+}
+
+function Venn({ frame, dataset, mapping, settings, colors }: Omit<Props, "type">) {
+  const analysis = analyzeSetIntersections(dataset.rows, mapping, settings.setInputMode); const useRadial = settings.vennLayout === "radial" || analysis.sets.length > 3;
+  return useRadial ? <RadialIntersections frame={frame} analysis={analysis} settings={settings} colors={colors} /> : <ClassicVenn frame={frame} analysis={analysis} settings={settings} colors={colors} />;
+}
+
+function UpSet({ frame, dataset, mapping, settings, colors }: Omit<Props, "type">) {
+  const analysis = analyzeSetIntersections(dataset.rows, mapping, settings.setInputMode); const maximumVisible = Math.max(1, Math.min(settings.upsetMaxIntersections, Math.floor(frame.plotWidth / 24))); const intersections = analysis.intersections.slice(0, maximumVisible); const layout = upsetAdaptiveLayout(frame.top, frame.plotHeight, analysis.sets.length, intersections.length, frame.plotWidth, settings.tickSize); const maximumIntersection = Math.max(...intersections.map((entry) => entry.size), 1); const maximumSet = Math.max(...analysis.sets.map((set) => analysis.setSizes.get(set) ?? 0), 1);
+  const summaryBarMaximumWidth = Math.max(24, frame.left - 50); const summaryFontSize = Math.max(7, settings.tickSize - 2); const summaryLabelCapacity = Math.max(1, Math.floor((frame.left - 18 - summaryBarMaximumWidth) / (summaryFontSize * 0.58)));
+  return <g data-plot-data data-plot-family="upset" data-input-mode={analysis.mode} data-content-height={layout.contentBottom - layout.barTop}>
+    <text data-plot-label x={frame.left} y={frame.top + 13} fill={TEXT} fontSize={settings.axisLabelSize} fontWeight={700}>Intersection size</text>
+    <line x1={frame.left} x2={frame.left + frame.plotWidth} y1={layout.baseline} y2={layout.baseline} stroke={TEXT} strokeWidth={settings.axisLineWidth} />
+    {intersections.map((entry, index) => { const height = entry.size / maximumIntersection * layout.barHeight; const x = frame.left + layout.band * (index + 0.5); const active = entry.sets.map((set) => analysis.sets.indexOf(set)); return <g key={entry.signature} data-plot-element="upset-intersection" data-intersection-signature={entry.signature} data-intersection-size={entry.size}><rect x={x - layout.band * 0.29} y={layout.baseline - height} width={layout.band * 0.58} height={height} rx={1} fill={colors[0]} fillOpacity={settings.opacity} /><text data-plot-label x={x} y={layout.baseline - height - 5} textAnchor="middle" fill={TEXT} fontSize={Math.max(8, settings.tickSize - 1)}>{entry.size}</text>{analysis.sets.map((set, setIndex) => <circle key={set} cx={x} cy={layout.matrixTop + setIndex * layout.rowGap} r={4.2} fill={entry.sets.includes(set) ? colors[1] ?? colors[0] : "#D5D6D8"} />)}{active.length > 1 ? <line x1={x} x2={x} y1={layout.matrixTop + Math.min(...active) * layout.rowGap} y2={layout.matrixTop + Math.max(...active) * layout.rowGap} stroke={colors[1] ?? colors[0]} strokeWidth={2} /> : null}<title>{`${entry.sets.join(" ∩ ")}: ${entry.size}`}</title></g>; })}
+    <text data-no-clip="true" x={4} y={frame.top + 13} fill={TEXT} fontSize={Math.max(8, settings.tickSize - 1)} fontWeight={700}>Set size</text>
+    {analysis.sets.map((set, index) => { const size = analysis.setSizes.get(set) ?? 0; const y = layout.matrixTop + index * layout.rowGap; const width = size / maximumSet * summaryBarMaximumWidth; const visible = set.length > summaryLabelCapacity ? `${set.slice(0, Math.max(1, summaryLabelCapacity - 1))}…` : set; return <g key={set} data-plot-element="upset-set-summary"><text data-no-clip="true" data-plot-element="upset-set-label" data-full-label={set} x={4} y={y + 3} fill={TEXT} fontSize={summaryFontSize}>{visible}<title>{set}</title></text><rect data-no-clip="true" data-plot-element="upset-set-bar" x={frame.left - 10 - width} y={y - 4} width={width} height={8} rx={1} fill={categoricalColorForIndex(index, colors)} fillOpacity={0.62} /><text data-no-clip="true" x={frame.left - 6} y={y + 3} fill={TEXT} fontSize={summaryFontSize}>{size}</text></g>; })}
+    <text data-no-clip="true" x={frame.left} y={frame.top + frame.plotHeight + 18} fill={TEXT} fontSize={Math.max(7, settings.tickSize - 3)}>{`${analysis.memberships.size} unique ${analysis.mode === "peak-overlap" ? "atomic genomic segments" : "items"} · ${analysis.intersections.length} exact intersections${analysis.duplicatesCollapsed ? ` · ${analysis.duplicatesCollapsed} duplicates collapsed` : ""}`}</text>
+  </g>;
+}
+
+export function ScientificSetPlot(props: Props) { return props.type === "venn" ? <Venn {...props} /> : <UpSet {...props} />; }

--- a/src/components/VisualizationStudio.tsx
+++ b/src/components/VisualizationStudio.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/Button";
 import { Card, CardBody, CardHeader } from "@/components/ui/Card";
 import { cn } from "@/lib/cn";
 import { analyzeExpressionMatrix, defaultPcaOptions, type PcaDataLayer, type PcaOptions } from "@/lib/visualization-pca";
+import { analyzeSetIntersections, intersectionExportTsv } from "@/lib/visualization-sets";
 import {
   defaultVisualizationPaletteSeriesId,
   defaultVisualizationSettings,
@@ -435,6 +436,7 @@ export function VisualizationStudio() {
   const [loadedFileName, setLoadedFileName] = useState("");
   const [fileError, setFileError] = useState("");
   const [stickyHeaderHeight, setStickyHeaderHeight] = useState(0);
+  const [selectedIntersectionSignature, setSelectedIntersectionSignature] = useState("");
   const svgRef = useRef<SVGSVGElement | null>(null);
   const fileRef = useRef<HTMLInputElement | null>(null);
   const stickyHeaderRef = useRef<HTMLDivElement | null>(null);
@@ -496,6 +498,11 @@ export function VisualizationStudio() {
   const invalidYLimits = manualAxes.includes("y") && settings.yMin !== null && settings.yMax !== null && settings.yMin >= settings.yMax;
   const pcaAnalysis = useMemo(() => plotType === "pca" ? analyzeExpressionMatrix(rawData, pcaOptions, pcaObservationMetadata) : null, [plotType, rawData, pcaObservationMetadata, pcaOptions]);
   const dataset = useMemo(() => pcaAnalysis?.dataset ?? parseDelimitedData(rawData), [pcaAnalysis, rawData]);
+  const setAnalysis = useMemo(
+    () => (plotType === "venn" || plotType === "upset") ? analyzeSetIntersections(dataset.rows, mapping, settings.setInputMode) : null,
+    [dataset.rows, mapping, plotType, settings.setInputMode],
+  );
+  const selectedSetIntersection = setAnalysis?.intersections.find((entry) => entry.signature === selectedIntersectionSignature) ?? setAnalysis?.intersections[0] ?? null;
   const barBreakRange = useMemo(() => {
     if (plotType !== "bar" || !mapping.value) return { minimum: -100, maximum: 100, step: 0.5 };
     const values = dataset.rows.flatMap((row) => {
@@ -561,8 +568,10 @@ export function VisualizationStudio() {
     setMapping(example.mapping ?? definition.defaultMapping);
     setLoadedFileName("");
     setFileError("");
+    setSelectedIntersectionSignature("");
     if (plotType === "pca") setPcaOptions(defaultPcaOptions);
     if (plotType === "bar") updateSetting("barInputMode", exampleIndex === 1 ? "long" : "summary");
+    if (plotType === "venn" || plotType === "upset") updateSetting("setInputMode", exampleIndex === 1 ? "peak-overlap" : "membership");
   };
 
   const selectPlot = (nextType: PlotType) => {
@@ -576,6 +585,7 @@ export function VisualizationStudio() {
     setMapping(nextExample.mapping ?? next.defaultMapping);
     setLoadedFileName("");
     setFileError("");
+    setSelectedIntersectionSignature("");
     if (nextType === "pca") setPcaOptions(defaultPcaOptions);
     setSettings((current) => settingsForDistributionPreset({
       ...current,
@@ -588,6 +598,7 @@ export function VisualizationStudio() {
       clusterColumns: nextType === "correlation-heatmap" ? current.clusterRows : current.clusterColumns,
       heatmapColumnClusters: nextType === "correlation-heatmap" ? current.heatmapRowClusters : current.heatmapColumnClusters,
       compositionLabelMode: nextType === "rose" ? "value" : current.compositionLabelMode,
+      setInputMode: (nextType === "venn" || nextType === "upset") ? "membership" : current.setInputMode,
       legendPosition: (["heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment", "enrichment-bar", "venn", "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos"] as PlotType[]).includes(nextType) && current.legendPosition === "bottom" ? "right" : current.legendPosition,
     }, nextType));
     window.requestAnimationFrame(() => {
@@ -725,6 +736,13 @@ export function VisualizationStudio() {
     const example = dataExamples[selectedExampleIndex >= 0 ? selectedExampleIndex : 0] ?? dataExamples[0];
     const metadata = example.metadata ?? "sample\tgroup\tbatch\tlabel\nSample_1\tControl\tBatch 1\tS1";
     downloadBlob(new Blob([metadata], { type: "text/tab-separated-values;charset=utf-8" }), `${slug(definition.name)}-observation-metadata-template.tsv`);
+  };
+
+  const downloadSelectedIntersection = () => {
+    if (!setAnalysis || !selectedSetIntersection) return;
+    const content = intersectionExportTsv(setAnalysis, selectedSetIntersection.signature);
+    const label = selectedSetIntersection.sets.join("-and-");
+    downloadBlob(new Blob([content], { type: "text/tab-separated-values;charset=utf-8" }), `${slug(definition.name)}-${slug(label)}-exact-members.tsv`);
   };
 
   const exportSvg = () => {
@@ -1022,6 +1040,13 @@ export function VisualizationStudio() {
               {(plotType === "line" || (plotType === "pca" && settings.ordinationView === "scores") || ((plotType === "scatter" || plotType === "correlation") && !["pair-matrix", "3d", "ternary"].includes(settings.associationVariant)) || (plotType === "bar" && !["horizontal", "bullet", "pyramid", "dual-axis", "overlay", "polar", "faceted"].includes(settings.barVariant))) ? <ToggleControl label="Swap axes" checked={settings.swapAxes} onChange={(value) => updateSetting("swapAxes", value)} /> : null}
               {(plotType === "scatter" || plotType === "correlation") && ["points", "marginal", "ellipse", "hull"].includes(settings.associationVariant) ? <ToggleControl label="Point labels" checked={settings.showLabels} onChange={(value) => updateSetting("showLabels", value)} /> : null}
               {(["pca", "pcoa", "umap", "tsne", "nmds", "quadrant"] as PlotType[]).includes(plotType) ? <ToggleControl label="Point labels" checked={settings.showLabels} onChange={(value) => updateSetting("showLabels", value)} /> : null}
+            </ControlGroup> : null}
+
+            {(plotType === "venn" || plotType === "upset") ? <ControlGroup title="Set intersections">
+              <SelectControl label="Input structure" value={settings.setInputMode} onChange={(value) => { updateSetting("setInputMode", value as VisualizationSettings["setInputMode"]); setSelectedIntersectionSignature(""); }}><option value="auto">Auto detect</option><option value="membership">Item–set membership</option><option value="peak-overlap">Genomic peak overlap</option></SelectControl>
+              {plotType === "venn" ? <><SelectControl label="Diagram layout" value={settings.vennLayout} onChange={(value) => updateSetting("vennLayout", value as VisualizationSettings["vennLayout"])}><option value="auto">Auto · circles / radial index</option><option value="classic">Classic circles · 2–3 sets</option><option value="radial">Radial exact intersections · 2–7 sets</option></SelectControl><ToggleControl label="Size-weighted visual cue" checked={settings.vennProportional} onChange={(value) => updateSetting("vennProportional", value)} /></> : <RangeControl label="Displayed intersections" value={settings.upsetMaxIntersections} minimum={3} maximum={30} step={1} onChange={(value) => updateSetting("upsetMaxIntersections", value)} />}
+              {setAnalysis && setAnalysis.intersections.length > 0 ? <><SelectControl label="Exact intersection to download" value={selectedSetIntersection?.signature ?? ""} onChange={setSelectedIntersectionSignature}>{setAnalysis.intersections.map((entry) => <option key={entry.signature} value={entry.signature}>{entry.sets.join(" ∩ ")} · n={entry.size}</option>)}</SelectControl><Button type="button" variant="secondary" size="sm" className="w-full justify-center" onClick={downloadSelectedIntersection}><Download className="h-3.5 w-3.5" aria-hidden />Download selected members</Button></> : null}
+              <p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Counts are exact membership combinations. Peak mode splits half-open intervals [start, end) into disjoint atomic genomic segments wherever active set membership changes; counts are segments, not base pairs or original peaks. Size weighting is only a visual cue, never an area-proportional fit.</p>
             </ControlGroup> : null}
 
             {plotType === "line" || (plotType === "bar" && !["stacked", "percentage", "polar"].includes(settings.barVariant)) ? <ControlGroup title={`${plotType === "bar" ? "Bar" : "Line"} uncertainty`}>

--- a/src/lib/visualization-sets.test.tsx
+++ b/src/lib/visualization-sets.test.tsx
@@ -1,0 +1,112 @@
+import { createRef } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ScientificChartPreview } from "@/components/ScientificChartPreview";
+import {
+  analyzeSetIntersections,
+  radialIntersectionLayout,
+  exactIntersectionCount,
+  intersectionExportTsv,
+  setDiagramLayoutMetrics,
+  upsetAdaptiveLayout,
+} from "./visualization-sets";
+import {
+  defaultVisualizationSettings,
+  defaultVisualizationThemeId,
+  getPlotDefinition,
+  parseDelimitedData,
+  plotModuleRegistry,
+  validatePlotDataset,
+} from "./visualization-studio";
+
+describe("set-intersection scientific contracts", () => {
+  it("deduplicates item–set rows and counts exact intersections", () => {
+    const dataset = parseDelimitedData("item\tset\na\tA\na\tB\na\tB\nb\tA\nc\tB\nd\tA\nd\tB\nd\tC\ne\tC");
+    const analysis = analyzeSetIntersections(dataset.rows, { item: "item", set: "set" }, "membership");
+    expect(analysis.sets).toEqual(["A", "B", "C"]);
+    expect(analysis.duplicatesCollapsed).toBe(1);
+    expect(analysis.setSizes).toEqual(new Map([["A", 3], ["B", 3], ["C", 2]]));
+    expect(exactIntersectionCount(analysis, ["A"])).toBe(1);
+    expect(exactIntersectionCount(analysis, ["A", "B"])).toBe(1);
+    expect(exactIntersectionCount(analysis, ["A", "B", "C"])).toBe(1);
+    expect(intersectionExportTsv(analysis, analysis.intersections.find((entry) => entry.sets.join("+") === "A+B")!.signature)).toContain("a\tA & B");
+  });
+
+  it("uses half-open atomic genomic segments with constant active-set membership", () => {
+    const dataset = parseDelimitedData("peak\tset\tchromosome\tstart\tend\na\tA\tchr1\t0\t10\nb\tB\tchr1\t9\t20\nc\tC\tchr1\t19\t30\nd\tD\tchr1\t30\t40\ne\tA\tchr2\t9\t20");
+    const mapping = { item: "peak", set: "set", chromosome: "chromosome", start: "start", end: "end" };
+    const analysis = analyzeSetIntersections(dataset.rows, mapping, "peak-overlap");
+    expect(analysis.memberships.size).toBe(7);
+    expect(exactIntersectionCount(analysis, ["A", "B", "C"])).toBe(0);
+    expect(exactIntersectionCount(analysis, ["A", "B"])).toBe(1);
+    expect(exactIntersectionCount(analysis, ["B", "C"])).toBe(1);
+    expect(exactIntersectionCount(analysis, ["D"])).toBe(1);
+    expect(exactIntersectionCount(analysis, ["A"])).toBe(2);
+    const pair = analysis.intersections.find((entry) => entry.sets.join("+") === "A+B")!;
+    const exported = intersectionExportTsv(analysis, pair.signature);
+    expect(exported.startsWith("atomic_segment\tchromosome\tstart\tend")).toBe(true);
+    expect(exported).toContain("\t1\t9\t10\tA & B\ta; b");
+  });
+
+  it("bounds provenance work for a 20,000-row adversarial nested peak input", () => {
+    const rows = [
+      ...Array.from({ length: 10_000 }, (_, index) => ({ peak: `A${index}`, set: "A", chromosome: "chr1", start: String(index), end: String(1_000_000 - index) })),
+      ...Array.from({ length: 10_000 }, (_, index) => ({ peak: `B${index}`, set: "B", chromosome: "chr1", start: String(20_000 + index * 2), end: String(20_001 + index * 2) })),
+    ];
+    const started = performance.now();
+    const analysis = analyzeSetIntersections(rows, { item: "peak", set: "set", chromosome: "chromosome", start: "start", end: "end" }, "peak-overlap");
+    expect(performance.now() - started).toBeLessThan(3_000);
+    expect(analysis.safetyError).toMatch(/provenance links/i);
+    expect(analysis.memberships.size).toBe(0);
+  });
+
+  it("orders sparse seven-set radial regions deterministically without invalid geometry", () => {
+    const rows = parseDelimitedData(["item\tset", ...Array.from({ length: 7 }, (_, index) => `only${index}\tS${index + 1}`), ...Array.from({ length: 7 }, (_, index) => `shared\tS${index + 1}`)].join("\n")).rows;
+    const analysis = analyzeSetIntersections(rows, { item: "item", set: "set" });
+    const regions = radialIntersectionLayout(analysis);
+    expect(regions).toHaveLength(8);
+    expect(new Set(regions.map((region) => region.signature)).size).toBe(8);
+    expect(regions.every((region) => Number.isFinite(region.start) && Number.isFinite(region.end) && region.span > 0)).toBe(true);
+    expect(setDiagramLayoutMetrics(600, 420, analysis, 11, false).fits).toBe(true);
+  });
+
+  it("adapts UpSet content to the available height instead of leaving a fixed blank tail", () => {
+    const compact = upsetAdaptiveLayout(24, 258, 7, 8, 280, 11);
+    const tall = upsetAdaptiveLayout(24, 718, 7, 8, 280, 11);
+    expect(compact.contentBottom).toBe(270);
+    expect(tall.contentBottom).toBe(730);
+    expect(tall.barHeight).toBeGreaterThan(compact.barHeight);
+    expect(compact.fits).toBe(true);
+  });
+
+  it("validates input-specific mappings, set limits, and compact region capacity", () => {
+    const venn = getPlotDefinition("venn");
+    const membership = parseDelimitedData("item\tset\na\tA\nb\tB");
+    expect(validatePlotDataset(venn, membership, { item: "item", set: "set", chromosome: "", start: "", end: "" }, { ...defaultVisualizationSettings, setInputMode: "membership" }).errors).toEqual([]);
+    const missingPeakCoordinates = validatePlotDataset(venn, membership, { item: "", set: "set", chromosome: "", start: "", end: "" }, { ...defaultVisualizationSettings, setInputMode: "peak-overlap" });
+    expect(missingPeakCoordinates.errors.join(" ")).toMatch(/requires chromosome, start, and end/i);
+    const eightSets = parseDelimitedData(["item\tset", ...Array.from({ length: 8 }, (_, index) => `i${index}\tS${index}`)].join("\n"));
+    expect(validatePlotDataset(venn, eightSets, venn.defaultMapping, { ...defaultVisualizationSettings, setInputMode: "membership" }).errors.join(" ")).toMatch(/2–7 unique sets/i);
+  });
+
+  it("renders exact region identities, set summaries, and finite SVG marks", () => {
+    for (const type of ["venn", "upset"] as const) {
+      const plotModule = plotModuleRegistry.get(type);
+      const example = plotModule.examples[0];
+      const dataset = parseDelimitedData(example.data);
+      const settings = { ...defaultVisualizationSettings, setInputMode: "membership" as const, vennLayout: "auto" as const };
+      const markup = renderToStaticMarkup(<ScientificChartPreview svgRef={createRef<SVGSVGElement>()} type={type} dataset={dataset} mapping={example.mapping ?? plotModule.definition.defaultMapping} settings={settings} themeId={defaultVisualizationThemeId} />);
+      expect(markup).toContain(`data-plot-family="${type === "venn" ? "venn-classic" : "upset"}"`);
+      expect(markup).toContain("data-intersection-signature");
+      if (type === "upset") expect(markup).toContain("data-plot-element=\"upset-set-summary\"");
+      expect(markup).not.toMatch(/(?:NaN|Infinity|-Infinity|undefined)/);
+    }
+  });
+
+  it("exposes only meaningful Venn and UpSet controls", () => {
+    expect(plotModuleRegistry.get("venn").capabilities.settingKeys).toEqual(expect.arrayContaining(["setInputMode", "vennLayout", "vennProportional"]));
+    expect(plotModuleRegistry.get("venn").capabilities.settingKeys).not.toContain("grid");
+    expect(plotModuleRegistry.get("upset").capabilities.settingKeys).toEqual(expect.arrayContaining(["setInputMode", "upsetMaxIntersections"]));
+    expect(plotModuleRegistry.get("upset").capabilities.settingKeys).not.toContain("xLabel");
+  });
+});

--- a/src/lib/visualization-sets.ts
+++ b/src/lib/visualization-sets.ts
@@ -1,0 +1,198 @@
+import { normalizeChromosome } from "./visualization-genomics";
+
+export type SetInputMode = "auto" | "membership" | "peak-overlap";
+export type SetRow = Record<string, string>;
+
+export type SetMemberMetadata = {
+  chromosome?: string;
+  start?: number;
+  end?: number;
+  contributingRecords: string[];
+};
+
+export type ExactIntersection = {
+  signature: string;
+  sets: string[];
+  size: number;
+  items: string[];
+};
+
+export type SetIntersectionAnalysis = {
+  mode: Exclude<SetInputMode, "auto">;
+  sets: string[];
+  memberships: Map<string, Set<string>>;
+  metadata: Map<string, SetMemberMetadata>;
+  setSizes: Map<string, number>;
+  intersections: ExactIntersection[];
+  duplicatesCollapsed: number;
+  invalidRows: number[];
+  sourceRows: number;
+  safetyError?: string;
+};
+
+const MAX_SET_ROWS = 20_000;
+const MAX_SET_COUNT = 20;
+const MAX_PROVENANCE_LINKS = 200_000;
+
+function clean(value: string | undefined) { return String(value ?? "").trim(); }
+
+export function resolveSetInputMode(rows: SetRow[], mapping: Record<string, string>, requested: SetInputMode): Exclude<SetInputMode, "auto"> {
+  if (requested !== "auto") return requested;
+  const intervalColumns = [mapping.chromosome, mapping.start, mapping.end];
+  return intervalColumns.every(Boolean) && rows.some((row) => intervalColumns.every((column) => clean(row[column]))) ? "peak-overlap" : "membership";
+}
+
+function finalizeAnalysis(mode: Exclude<SetInputMode, "auto">, sets: string[], memberships: Map<string, Set<string>>, metadata: Map<string, SetMemberMetadata>, duplicatesCollapsed: number, invalidRows: number[], sourceRows: number): SetIntersectionAnalysis {
+  const intersectionItems = new Map<string, string[]>();
+  memberships.forEach((membership, item) => {
+    const signature = sets.filter((set) => membership.has(set)).join("\u0001");
+    if (!signature) return;
+    const items = intersectionItems.get(signature) ?? [];
+    items.push(item);
+    intersectionItems.set(signature, items);
+  });
+  const intersections = [...intersectionItems.entries()].map(([signature, items]) => ({ signature, sets: signature.split("\u0001"), size: items.length, items: [...items].sort((a, b) => a.localeCompare(b, undefined, { numeric: true })) })).sort((a, b) => b.size - a.size || a.sets.length - b.sets.length || a.signature.localeCompare(b.signature));
+  return {
+    mode,
+    sets,
+    memberships,
+    metadata,
+    setSizes: new Map(sets.map((set) => [set, [...memberships.values()].filter((membership) => membership.has(set)).length])),
+    intersections,
+    duplicatesCollapsed,
+    invalidRows,
+    sourceRows,
+  };
+}
+
+export function analyzeSetIntersections(rows: SetRow[], mapping: Record<string, string>, requested: SetInputMode = "auto"): SetIntersectionAnalysis {
+  const mode = resolveSetInputMode(rows, mapping, requested);
+  const detectedSets = [...new Set(rows.map((row) => clean(row[mapping.set])).filter(Boolean))];
+  const stoppedAnalysis = (safetyError: string): SetIntersectionAnalysis => ({ mode, sets: detectedSets, memberships: new Map(), metadata: new Map(), setSizes: new Map(), intersections: [], duplicatesCollapsed: 0, invalidRows: [], sourceRows: rows.length, safetyError });
+  if (rows.length > MAX_SET_ROWS) return stoppedAnalysis(`Set-intersection analysis accepts at most ${MAX_SET_ROWS.toLocaleString()} input rows; detected ${rows.length.toLocaleString()}.`);
+  if (detectedSets.length > MAX_SET_COUNT) return stoppedAnalysis(`Set-intersection analysis accepts at most ${MAX_SET_COUNT} sets; detected ${detectedSets.length}.`);
+  const sets: string[] = [];
+  const rememberSet = (set: string) => { if (set && !sets.includes(set)) sets.push(set); };
+  const memberships = new Map<string, Set<string>>();
+  const metadata = new Map<string, SetMemberMetadata>();
+  const invalidRows: number[] = [];
+  let duplicatesCollapsed = 0;
+
+  if (mode === "membership") {
+    rows.forEach((row, index) => {
+      const item = clean(row[mapping.item]); const set = clean(row[mapping.set]);
+      if (!item || !set) { invalidRows.push(index + 2); return; }
+      rememberSet(set);
+      const membership = memberships.get(item) ?? new Set<string>();
+      if (membership.has(set)) duplicatesCollapsed += 1;
+      membership.add(set); memberships.set(item, membership);
+      metadata.set(item, { contributingRecords: [item] });
+    });
+    return finalizeAnalysis(mode, sets, memberships, metadata, duplicatesCollapsed, invalidRows, rows.length);
+  }
+
+  type Peak = { chromosome: string; start: number; end: number; set: string; label: string; row: number };
+  const peaks: Peak[] = [];
+  const peakKeys = new Set<string>();
+  rows.forEach((row, index) => {
+    const chromosomeText = clean(row[mapping.chromosome]); const chromosome = normalizeChromosome(chromosomeText); const set = clean(row[mapping.set]);
+    const startText = clean(row[mapping.start]); const endText = clean(row[mapping.end]); const start = Number(startText); const end = Number(endText);
+    if (!chromosomeText || !chromosome || !set || !startText || !endText || !Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start < 0 || end <= start) { invalidRows.push(index + 2); return; }
+    rememberSet(set);
+    const key = `${chromosome}\u0000${start}\u0000${end}\u0000${set}`;
+    if (peakKeys.has(key)) { duplicatesCollapsed += 1; return; }
+    peakKeys.add(key);
+    peaks.push({ chromosome, start, end, set, label: clean(row[mapping.item]) || `${set}:${chromosome}:${start}-${end}`, row: index + 2 });
+  });
+  const byChromosome = new Map<string, Peak[]>();
+  peaks.forEach((peak) => { const list = byChromosome.get(peak.chromosome) ?? []; list.push(peak); byChromosome.set(peak.chromosome, list); });
+  let segmentIndex = 0; let provenanceOverflow = false; let provenanceLinks = 0;
+  byChromosome.forEach((chromosomePeaks, chromosome) => {
+    if (provenanceOverflow) return;
+    const events = new Map<number, { add: Peak[]; remove: Peak[] }>();
+    const eventAt = (position: number) => { const event = events.get(position) ?? { add: [], remove: [] }; events.set(position, event); return event; };
+    chromosomePeaks.forEach((peak) => { eventAt(peak.start).add.push(peak); eventAt(peak.end).remove.push(peak); });
+    const positions = [...events.keys()].sort((a, b) => a - b); const activeCounts = new Map<string, number>(); const activeLabels = new Map<number, string>();
+    type AtomicSegment = { start: number; end: number; sets: Set<string>; labels: Set<string>; signature: string };
+    const segments: AtomicSegment[] = []; let current: AtomicSegment | null = null;
+    for (let positionIndex = 0; positionIndex < positions.length - 1; positionIndex += 1) {
+      const position = positions[positionIndex];
+      const event = events.get(position)!;
+      event.remove.forEach((peak) => { activeLabels.delete(peak.row); const next = (activeCounts.get(peak.set) ?? 1) - 1; if (next <= 0) activeCounts.delete(peak.set); else activeCounts.set(peak.set, next); });
+      event.add.forEach((peak) => { activeLabels.set(peak.row, peak.label); activeCounts.set(peak.set, (activeCounts.get(peak.set) ?? 0) + 1); });
+      const next = positions[positionIndex + 1];
+      if (next <= position || activeCounts.size === 0) { current = null; continue; }
+      const activeSets = new Set(activeCounts.keys());
+      const signature = sets.filter((set) => activeSets.has(set)).join("\u0001");
+      if (current && current.end === position && current.signature === signature) {
+        current.end = next;
+        event.add.forEach((peak) => { if (!current!.labels.has(peak.label)) { current!.labels.add(peak.label); provenanceLinks += 1; } });
+      } else {
+        const labels = new Set(activeLabels.values()); provenanceLinks += labels.size;
+        current = { start: position, end: next, sets: activeSets, labels, signature }; segments.push(current);
+      }
+      if (provenanceLinks > MAX_PROVENANCE_LINKS) { provenanceOverflow = true; return; }
+    }
+    if (provenanceOverflow) return;
+    segments.forEach((segment) => {
+      segmentIndex += 1; const item = `${chromosome}:${segment.start}-${segment.end}#${segmentIndex}`;
+      memberships.set(item, segment.sets);
+      metadata.set(item, { chromosome, start: segment.start, end: segment.end, contributingRecords: [...segment.labels] });
+    });
+  });
+  if (provenanceOverflow) return stoppedAnalysis(`Atomic genomic segmentation would retain more than ${MAX_PROVENANCE_LINKS.toLocaleString()} segment-to-peak provenance links. Pre-merge peaks within each set or filter to a documented region.`);
+  return finalizeAnalysis(mode, sets, memberships, metadata, duplicatesCollapsed, invalidRows, rows.length);
+}
+
+export function exactIntersectionCount(analysis: SetIntersectionAnalysis, wanted: string[]) {
+  const signature = analysis.sets.filter((set) => wanted.includes(set)).join("\u0001");
+  return analysis.intersections.find((intersection) => intersection.signature === signature)?.size ?? 0;
+}
+
+export function intersectionExportTsv(analysis: SetIntersectionAnalysis, signature: string) {
+  const intersection = analysis.intersections.find((entry) => entry.signature === signature);
+  if (!intersection) return "";
+  if (analysis.mode === "membership") return ["item\texact_intersection", ...intersection.items.map((item) => `${item}\t${intersection.sets.join(" & ")}`)].join("\n");
+  return ["atomic_segment\tchromosome\tstart\tend\texact_intersection\tcontributing_records", ...intersection.items.map((item) => { const entry = analysis.metadata.get(item); return [item, entry?.chromosome ?? "", entry?.start ?? "", entry?.end ?? "", intersection.sets.join(" & "), (entry?.contributingRecords ?? []).join("; ")].join("\t"); })].join("\n");
+}
+
+export function grayCode(value: number) { return value ^ (value >> 1); }
+
+export function radialIntersectionLayout(analysis: SetIntersectionAnalysis, startAngle = -Math.PI / 2, sizeWeighted = false) {
+  const ordered = [...analysis.intersections].sort((a, b) => {
+    const mask = (entry: ExactIntersection) => analysis.sets.reduce((value, set, index) => value | (entry.sets.includes(set) ? (1 << index) : 0), 0);
+    return grayCode(mask(a)) - grayCode(mask(b));
+  });
+  const total = ordered.reduce((sum, entry) => sum + entry.size, 0);
+  const gap = Math.min(0.025, Math.PI / Math.max(120, ordered.length * 12));
+  const usable = Math.PI * 2 - gap * ordered.length;
+  let cursor = startAngle;
+  return ordered.map((entry) => {
+    const fraction = sizeWeighted ? entry.size / Math.max(total, 1) : 1 / Math.max(ordered.length, 1);
+    const span = usable * fraction;
+    const region = { ...entry, start: cursor, end: cursor + span, middle: cursor + span / 2, span };
+    cursor += span + gap;
+    return region;
+  });
+}
+
+export function setDiagramLayoutMetrics(width: number, height: number, analysis: SetIntersectionAnalysis, tickSize: number, sizeWeighted: boolean) {
+  const plotWidth = Math.max(100, width - 36); const plotHeight = Math.max(90, height - 82); const radius = Math.min(plotWidth, plotHeight) * 0.33;
+  const regions = radialIntersectionLayout(analysis, -Math.PI / 2, sizeWeighted);
+  const minimumArc = regions.length ? Math.min(...regions.map((region) => region.span * radius)) : 0;
+  const minimumLabelArc = Math.max(9, tickSize * 0.88);
+  return { radius, regions, minimumArc, minimumLabelArc, fits: analysis.sets.length >= 2 && analysis.sets.length <= 7 && regions.length <= 32 && minimumArc >= minimumLabelArc };
+}
+
+export function upsetAdaptiveLayout(frameTop: number, plotHeight: number, setCount: number, intersectionCount: number, plotWidth: number, tickSize: number) {
+  const rowGap = Math.max(13, Math.min(25, (plotHeight * 0.36) / Math.max(1, setCount - 1)));
+  const matrixHeight = Math.max(0, setCount - 1) * rowGap;
+  const contentBottom = frameTop + plotHeight - 12;
+  const matrixTop = contentBottom - matrixHeight;
+  const baseline = matrixTop - 24;
+  const barTop = frameTop + 28;
+  const barHeight = Math.max(30, baseline - barTop);
+  const band = plotWidth / Math.max(1, intersectionCount);
+  const fits = setCount >= 2 && setCount <= 20 && rowGap >= Math.max(10, tickSize + 1) && band >= 24 && barHeight >= 30;
+  return { rowGap, matrixHeight, contentBottom, matrixTop, baseline, barTop, barHeight, band, fits };
+}

--- a/src/lib/visualization-studio.ts
+++ b/src/lib/visualization-studio.ts
@@ -38,6 +38,11 @@ import {
   parseCircosTrackRecords,
   parseLigandReceptorRecords,
 } from "./visualization-flow-circular";
+import {
+  analyzeSetIntersections,
+  setDiagramLayoutMetrics,
+  upsetAdaptiveLayout,
+} from "./visualization-sets";
 
 export type PlotType =
   | "bar"
@@ -343,6 +348,10 @@ export type VisualizationSettings = {
   networkShowIsolates: boolean;
   networkEdgeOpacity: number;
   treeOrientation: "vertical" | "horizontal";
+  setInputMode: "auto" | "membership" | "peak-overlap";
+  vennLayout: "auto" | "classic" | "radial";
+  vennProportional: boolean;
+  upsetMaxIntersections: number;
   correlationMethod: "pearson" | "spearman";
   xThreshold: number;
   yThreshold: number;
@@ -472,6 +481,10 @@ export const defaultVisualizationSettings: VisualizationSettings = {
   networkShowIsolates: true,
   networkEdgeOpacity: 0.62,
   treeOrientation: "vertical",
+  setInputMode: "auto",
+  vennLayout: "auto",
+  vennProportional: false,
+  upsetMaxIntersections: 10,
   correlationMethod: "pearson",
   xThreshold: 0,
   yThreshold: 0,
@@ -1281,6 +1294,19 @@ AKT1\tProteomics
 TP53\tCRISPR
 AKT1\tCRISPR
 KRAS\tCRISPR`,
+  setPeaks: `peak_id\tset\tchromosome\tstart\tend
+RNA_1\tRNA-seq\tchr1\t100\t180
+RNA_2\tRNA-seq\tchr1\t260\t330
+RNA_3\tRNA-seq\tchr2\t500\t570
+ATAC_1\tATAC-seq\tchr1\t140\t220
+ATAC_2\tATAC-seq\tchr1\t300\t380
+ATAC_3\tATAC-seq\tchr2\t700\t760
+H3K27ac_1\tH3K27ac\tchr1\t160\t205
+H3K27ac_2\tH3K27ac\tchr2\t530\t610
+H3K27ac_3\tH3K27ac\tchr2\t720\t790
+TF_1\tTF ChIP-seq\tchr1\t175\t240
+TF_2\tTF ChIP-seq\tchr2\t540\t590
+TF_3\tTF ChIP-seq\tchr3\t80\t140`,
   network: `source\ttarget\tvalue\tgroup
 Tumor\tT cell\t18\tImmune
 Tumor\tMacrophage\t12\tImmune
@@ -1898,14 +1924,21 @@ const plotDefinitionSeeds: PlotDefinition[] = [
     id,
     name: id === "venn" ? "Venn" : "UpSet",
     family: "Set relationships",
-    summary: id === "venn" ? "Two- or three-set overlap with exact region counts." : "Scalable set intersections with membership matrix and ranked intersection sizes.",
-    inputHint: id === "venn" ? "Long format item/set membership. Venn is restricted to 2–3 unique sets." : "Long format item/set membership; duplicate memberships are collapsed.",
+    summary: id === "venn" ? "Exact two-to-seven-set intersections using classic circles or a compact radial exact-intersection layout." : "Adaptive ranked exact intersections with a membership matrix, set-size summaries, and downloadable members.",
+    inputHint: "Use item–set membership rows, or genomic peak intervals (set, chromosome, start, end). Duplicate rows collapse; peak counts are disjoint atomic genomic segments with constant active-set membership.",
     roles: [
-      { key: "item", label: "Item", kind: "label" as const, required: true },
+      { key: "item", label: "Item / peak ID", kind: "label" as const, required: false },
       { key: "set", label: "Set", kind: "category" as const, required: true },
+      { key: "chromosome", label: "Chromosome (peak input)", kind: "category" as const, required: false },
+      { key: "start", label: "Start (peak input)", kind: "number" as const, required: false },
+      { key: "end", label: "End (peak input)", kind: "number" as const, required: false },
     ],
-    defaultMapping: { item: "item", set: "set" },
+    defaultMapping: { item: "item", set: "set", chromosome: "", start: "", end: "" },
     sampleData: samples.sets,
+    examples: [
+      { label: "Example 1 · Membership", description: "Long-form item–set membership; repeated item–set rows are deduplicated before exact combinations are counted.", data: samples.sets, mapping: { item: "item", set: "set", chromosome: "", start: "", end: "" } },
+      { label: "Example 2 · Peak overlap", description: "Half-open genomic intervals split into disjoint chromosome-specific segments wherever the active set membership changes.", data: samples.setPeaks, mapping: { item: "peak_id", set: "set", chromosome: "chromosome", start: "start", end: "end" } },
+    ],
   })),
   ...(["sankey", "chord"] as const).map((id) => ({
     id,
@@ -2494,16 +2527,16 @@ const plotGuidanceSeeds: Record<PlotType, PlotGuidance> = {
     references: [plotReferences.roc],
   },
   venn: {
-    definition: "用重叠闭合区域表示集合及其交集；区域位置表达集合逻辑，但面积通常不严格按成员数成比例。",
-    suitableData: "2–3 个集合的成员关系，如基因、蛋白、峰、样本或候选条目列表。",
-    answers: "少量集合之间独有和共享成员各有多少。",
-    origin: "John Venn 在 1880 年为形式逻辑系统化这类集合关系图；现代生物学后来把它用于少量基因或候选集合比较。",
-    references: [plotReferences.venn],
+    definition: "用经典圆形（2–3 集合）或径向精确交集索引（4–7 集合）表示观察到的集合组合；径向模式不是闭合曲线 Venn 图。",
+    suitableData: "2–7 个集合的 item–set 成员长表，或带 set、chromosome、start、end 的 genomic peak 区间。",
+    answers: "少量集合之间独有和共享成员各有多少；size-weighted 模式只是视觉提示，不是面积拟合，仍应以区域数字作为精确计数。",
+    origin: "John Venn 在 1880 年系统化集合关系图；当集合多于三个时，本工具改用可辨认的径向精确交集索引，不把它冒充为经典 Venn 闭合曲线。",
+    references: [plotReferences.venn, plotReferences.upset],
   },
   upset: {
     definition: "用点阵列明确标出参与某个交集的集合，再用柱长显示该精确交集的大小。",
-    suitableData: "三个及以上集合的成员关系，尤其适合交集组合较多的情况。",
-    answers: "哪些集合组合构成主要交集，各交集和单集合规模分别多大。",
+    suitableData: "两个及以上集合的 item–set 成员关系或 genomic peak 区间，尤其适合交集组合较多的情况。",
+    answers: "哪些精确集合组合构成主要交集，各交集和单集合规模分别多大，并可下载所选交集的明确成员清单。",
     origin: "Lex 等人在 2014 年提出 UpSet，目标是把难以扩展到许多集合的 Venn 图转换为可排序、可查询的矩阵视图。",
     references: [plotReferences.upset],
   },
@@ -2760,6 +2793,8 @@ const specializedSettingKeys: Partial<Record<PlotType, Array<keyof Visualization
   chord: ["showLabels"],
   "ligand-receptor": ["showLabels"],
   circos: ["showLabels", "genomicTrackGap", "continuousLow", "continuousHigh"],
+  venn: ["setInputMode", "vennLayout", "vennProportional"],
+  upset: ["setInputMode", "upsetMaxIntersections"],
   network: ["showLabels", "networkLayout", "networkSeed", "networkShowIsolates", "networkEdgeOpacity"],
   ppi: ["showLabels", "networkLayout", "networkSeed", "networkShowIsolates", "networkEdgeOpacity"],
   cerna: ["showLabels", "networkLayout", "networkSeed", "networkShowIsolates", "networkEdgeOpacity"],
@@ -2771,6 +2806,8 @@ const specializedSettingKeys: Partial<Record<PlotType, Array<keyof Visualization
 };
 
 const newAxislessSettingKeys: Partial<Record<PlotType, ReadonlySet<keyof VisualizationSettings>>> = {
+  venn: new Set(["title", "fontFamily", "width", "height", "titleSize", "axisLabelSize", "tickSize", "dataLineWidth", "opacity", "categoricalColors", "setInputMode", "vennLayout", "vennProportional"]),
+  upset: new Set(["title", "fontFamily", "width", "height", "titleSize", "axisLabelSize", "tickSize", "axisLineWidth", "opacity", "categoricalColors", "setInputMode", "upsetMaxIntersections"]),
   sankey: new Set(["title", "fontFamily", "width", "height", "titleSize", "tickSize", "opacity", "categoricalColors", "showLabels"]),
   alluvial: new Set(["title", "fontFamily", "width", "height", "titleSize", "tickSize", "opacity", "categoricalColors", "showLabels"]),
   chord: new Set(["title", "fontFamily", "width", "height", "titleSize", "tickSize", "opacity", "categoricalColors", "showLabels"]),
@@ -2841,6 +2878,10 @@ export function isPlotRoleActive(type: PlotType, roleKey: string, settings: Visu
   if (["pca", "pcoa", "umap", "tsne", "nmds"].includes(type)) {
     if (settings.ordinationView === "scree") return false;
     if (roleKey === "z") return settings.ordinationView === "3d";
+  }
+  if (type === "venn" || type === "upset") {
+    if (roleKey === "item") return settings.setInputMode !== "peak-overlap";
+    if (["chromosome", "start", "end"].includes(roleKey)) return settings.setInputMode !== "membership";
   }
   if (type !== "bar") return true;
   if (roleKey === "secondary") return ["dual-axis", "overlay"].includes(settings.barVariant);
@@ -3979,9 +4020,42 @@ export function validatePlotDataset(
     if (invalidIntervals > 0) errors.push(`${invalidIntervals} confidence interval${invalidIntervals === 1 ? " is" : "s are"} not ordered lower ≤ estimate ≤ upper.`);
   }
 
-  if (definition.id === "venn" && mapping.set) {
-    const setCount = new Set(dataset.rows.map((row) => row[mapping.set]).filter(Boolean)).size;
-    if (setCount < 2 || setCount > 3) errors.push(`Venn diagrams require 2–3 unique sets; detected ${setCount}. Use UpSet for more sets.`);
+  if ((definition.id === "venn" || definition.id === "upset") && mapping.set) {
+    const requestedMode = settings?.setInputMode ?? "auto";
+    const analysis = analyzeSetIntersections(dataset.rows, mapping, requestedMode);
+    if (analysis.safetyError) errors.push(analysis.safetyError);
+    if (analysis.mode === "membership" && !mapping.item) errors.push("Item ID must be mapped for item–set membership input.");
+    if (analysis.mode === "peak-overlap") {
+      const missingIntervalRoles = ["chromosome", "start", "end"].filter((role) => !mapping[role]);
+      if (missingIntervalRoles.length > 0) errors.push(`Peak-overlap input requires chromosome, start, and end mappings; missing ${missingIntervalRoles.join(", ")}.`);
+      if (!analysis.safetyError && analysis.invalidRows.length === 0) warnings.push("Peak overlaps use half-open intervals [start, end). Counts refer to disjoint atomic genomic segments over which the active set combination is constant; they are segment counts, not base-pair totals or original peak counts.");
+    }
+    if (analysis.invalidRows.length > 0) errors.push(`${analysis.invalidRows.length} set row${analysis.invalidRows.length === 1 ? " is" : "s are"} incomplete or invalid (rows ${analysis.invalidRows.slice(0, 8).join(", ")}${analysis.invalidRows.length > 8 ? ", …" : ""}).`);
+    if (!analysis.safetyError && analysis.memberships.size < 1) errors.push("No valid set members or atomic genomic segments were detected.");
+    if (analysis.duplicatesCollapsed > 0) warnings.push(`${analysis.duplicatesCollapsed} duplicate record${analysis.duplicatesCollapsed === 1 ? " was" : "s were"} collapsed before exact intersections were counted.`);
+    const setCount = analysis.sets.length;
+    if (definition.id === "venn") {
+      if (setCount < 2 || setCount > 7) errors.push(`Venn/radial intersection diagrams require 2–7 unique sets; detected ${setCount}. Use UpSet for larger collections.`);
+      const requestedLayout = settings?.vennLayout ?? "auto";
+      if (requestedLayout === "classic" && setCount > 3) errors.push("Classic circle Venn layout supports 2–3 sets; choose Auto or Radial exact intersections for 4–7 sets.");
+      const useRadial = requestedLayout === "radial" || (requestedLayout === "auto" && setCount > 3);
+      if (useRadial && settings) {
+        const layout = setDiagramLayoutMetrics(settings.width, settings.height, analysis, settings.tickSize, settings.vennProportional);
+        if (!layout.fits) errors.push(`The ${analysis.intersections.length} observed exact regions need at least ${layout.minimumLabelArc.toFixed(1)} px each, but the smallest radial region has ${layout.minimumArc.toFixed(1)} px; increase figure size, turn off size weighting, filter the data, or use UpSet.`);
+      }
+      if (settings?.vennProportional) warnings.push("Size weighting is a visual cue, not an area-proportional Venn fit; printed numbers remain the authoritative exact-intersection counts.");
+    } else {
+      if (setCount < 2 || setCount > 20) errors.push(`UpSet supports 2–20 sets in the compact studio; detected ${setCount}.`);
+      if (settings) {
+        const left = Math.min(178, settings.width * 0.32);
+        const top = settings.title ? 48 : 24;
+        const plotWidth = Math.max(100, settings.width - left - 22);
+        const plotHeight = Math.max(90, settings.height - top - 58);
+        const visibleIntersections = Math.max(1, Math.min(settings.upsetMaxIntersections, analysis.intersections.length, Math.floor(plotWidth / 24)));
+        const layout = upsetAdaptiveLayout(top, plotHeight, setCount, visibleIntersections, plotWidth, settings.tickSize);
+        if (!layout.fits) errors.push(`The UpSet matrix cannot keep ${setCount} set rows and ${visibleIntersections} intersections legible at ${settings.width} × ${settings.height} px; increase the figure size, reduce sets, or show fewer intersections.`);
+      }
+    }
   }
 
   const explicitNetworkTypes: NetworkPlotType[] = ["network", "ppi", "cerna", "mirna-target", "cnet", "enrichment-map"];

--- a/tests/e2e/visualization-studio.spec.ts
+++ b/tests/e2e/visualization-studio.spec.ts
@@ -873,4 +873,78 @@ test.describe("Visualization Studio browser acceptance", () => {
     await expect(page.getByText(/scatter diameter within its track band/i)).toBeVisible();
     await expect(page.getByRole("button", { name: "SVG" })).toBeDisabled();
   });
+
+  test("counts, lays out, and downloads exact Venn and UpSet intersections", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop-chromium", "Desktop set-intersection acceptance");
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /^Venn/ }).click();
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const venn = page.locator("svg[aria-label='Venn scientific figure preview']");
+    await expect(venn.locator("[data-plot-family='venn-classic']")).toHaveCount(1);
+    await expect(venn.locator("[data-plot-element='set-region-label']")).toHaveCount(7);
+    await expect(venn.locator("[data-intersection-signature='RNA-seq\u0001Proteomics\u0001CRISPR']")).toContainText("1");
+
+    await page.getByRole("button", { name: /Example 2.*Peak overlap/ }).click();
+    await expect(page.getByRole("combobox", { name: "Input structure" })).toHaveValue("peak-overlap");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    await expect(venn.locator("[data-plot-family='venn-radial'][data-input-mode='peak-overlap']")).toHaveCount(1);
+
+    const sevenSetRows = ["item\tset", ...Array.from({ length: 7 }, (_, index) => `only${index + 1}\tSet ${index + 1}`), ...Array.from({ length: 7 }, (_, index) => `shared\tSet ${index + 1}`)].join("\n");
+    await page.getByRole("combobox", { name: "Input structure" }).selectOption("membership");
+    await page.getByRole("textbox", { name: "CSV or TSV data" }).fill(sevenSetRows);
+    await page.getByRole("button", { name: "Auto-map" }).click();
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    await expect(venn.locator("[data-layout='radial-exact-intersections'] [data-plot-element='radial-intersection-region']")).toHaveCount(8);
+    const radialSafety = await venn.evaluate((element) => {
+      const clip = element.querySelector("clipPath rect")!;
+      const left = Number(clip.getAttribute("x")); const top = Number(clip.getAttribute("y")); const right = left + Number(clip.getAttribute("width")); const bottom = top + Number(clip.getAttribute("height"));
+      const labels = [...element.querySelectorAll<SVGGraphicsElement>("[data-plot-element='set-region-label']")];
+      const boxes = labels.map((label) => label.getBBox());
+      let collisions = 0;
+      for (let first = 0; first < boxes.length; first += 1) for (let second = first + 1; second < boxes.length; second += 1) { const a = boxes[first]; const b = boxes[second]; if (a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y) collisions += 1; }
+      return { collisions, outside: boxes.filter((box) => box.x < left || box.x + box.width > right || box.y < top || box.y + box.height > bottom).length };
+    });
+    expect(radialSafety).toEqual({ collisions: 0, outside: 0 });
+
+    await page.getByRole("button", { name: /^UpSet/ }).click();
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const upset = page.locator("svg[aria-label='UpSet scientific figure preview']");
+    await expect(upset.locator("[data-plot-element='upset-set-summary']")).toHaveCount(3);
+    const visibleSetSummary = await upset.evaluate((element) => {
+      const marks = [...element.querySelectorAll<SVGGraphicsElement>("[data-plot-element='upset-set-summary'] rect, [data-plot-element='upset-set-summary'] text")];
+      return { clipped: marks.filter((mark) => getComputedStyle(mark).clipPath !== "none").length, empty: marks.filter((mark) => { const box = mark.getBoundingClientRect(); return box.width <= 0 || box.height <= 0; }).length };
+    });
+    expect(visibleSetSummary).toEqual({ clipped: 0, empty: 0 });
+    const bottomGap = await upset.evaluate((element) => {
+      const clip = element.querySelector("clipPath rect")!;
+      const bottom = Number(clip.getAttribute("y")) + Number(clip.getAttribute("height"));
+      const circles = [...element.querySelectorAll<SVGCircleElement>("[data-plot-element='upset-intersection'] circle")];
+      return bottom - Math.max(...circles.map((circle) => Number(circle.getAttribute("cy"))));
+    });
+    expect(bottomGap).toBeLessThanOrEqual(14);
+    expect(bottomGap).toBeGreaterThanOrEqual(10);
+
+    await page.getByRole("combobox", { name: "Exact intersection to download" }).selectOption({ label: "RNA-seq ∩ Proteomics ∩ CRISPR · n=1" });
+    const download = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Download selected members" }).click();
+    const downloaded = await download;
+    expect(downloaded.suggestedFilename()).toMatch(/upset-rna-seq-and-proteomics-and-crispr-exact-members\.tsv/);
+    const path = await downloaded.path();
+    expect(path).not.toBeNull();
+    expect(await readFile(path!, "utf8")).toBe("item\texact_intersection\nTP53\tRNA-seq & Proteomics & CRISPR");
+
+    const longSetRows = "item\tset\na\tExtremely long transcriptomic discovery cohort\nb\tExtremely long proteomic validation cohort\nc\tExtremely long CRISPR perturbation cohort\nd\tExtremely long transcriptomic discovery cohort\nd\tExtremely long proteomic validation cohort";
+    await page.getByRole("textbox", { name: "CSV or TSV data" }).fill(longSetRows);
+    const tickSize = page.getByRole("textbox", { name: "Tick size value", exact: true });
+    await tickSize.fill("16");
+    await tickSize.press("Enter");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const summaryCollisions = await upset.evaluate((element) => [...element.querySelectorAll<SVGGElement>("[data-plot-element='upset-set-summary']")].filter((summary) => {
+      const label = summary.querySelector<SVGTextElement>("[data-plot-element='upset-set-label']")!.getBoundingClientRect();
+      const bar = summary.querySelector<SVGRectElement>("[data-plot-element='upset-set-bar']")!.getBoundingClientRect();
+      return label.right > bar.left - 1;
+    }).length);
+    expect(summaryCollisions).toBe(0);
+  });
 });


### PR DESCRIPTION
Closes #14

## What changed
- adds one shared exact-intersection analysis core for item–set membership and genomic peak input
- splits half-open genomic intervals into disjoint atomic segments with constant active-set membership; exports coordinates and contributing peak IDs
- supports classic 2–3-set Venn and an explicitly named radial exact-intersection index for 4–7 sets (not mislabeled as an Edwards closed-curve Venn)
- adds size-weighted visual cues with explicit non-proportional disclosure
- rebuilds UpSet with adaptive height, set-size summaries, exact-intersection selection, and TSV member download
- adds row/set/provenance safety limits, duplicate collapse disclosure, responsive label truncation, and clipping protection

## Verification
- 145 Vitest tests passed
- TypeScript passed
- ESLint passed
- Next.js 16 webpack production build passed
- Playwright: 16 passed, 10 intentionally skipped by viewport/project
- independent scientific-specification review: Clean
- independent engineering/visual review: Clean