### PR TITLE
Add clinically explicit evaluation and model-development plots

### DIFF
--- a/src/components/ScientificAdvancedChartPreview.tsx
+++ b/src/components/ScientificAdvancedChartPreview.tsx
@@ -5,6 +5,7 @@ import { ScientificGenomicPlot, isGenomicPlotType } from "@/components/Scientifi
 import { ScientificRelationshipPlot, isRelationshipPlotType } from "@/components/ScientificNetworkChartPreview";
 import { ScientificFlowCircularPlot } from "@/components/ScientificFlowCircularChartPreview";
 import { ScientificSetPlot } from "@/components/ScientificSetChartPreview";
+import { ScientificClinicalPlot, type ClinicalPlotType } from "@/components/ScientificClinicalChartPreview";
 import { genomicFrameMetrics } from "@/lib/visualization-genomics";
 import { networkFrameMetrics } from "@/lib/visualization-network";
 import {
@@ -78,7 +79,7 @@ function frameFor(type: PlotType, settings: VisualizationSettings): Frame {
   const heatmapType = ["heatmap", "clustered-heatmap", "correlation-heatmap"].includes(type);
   const hasHeatmapAnnotationLegend = heatmapType && Boolean(settings.heatmapRowAnnotationData.trim() || settings.heatmapColumnAnnotationData.trim());
   const labelHeavy = ["heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment-bar", "survival-forest", "upset", "genome-tracks", "oncoplot"].includes(type);
-  const hasLegend = !["box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "heatmap", "clustered-heatmap", "correlation-heatmap", "venn", "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos", "treemap", "manhattan", "qq", "chromosome-ideogram", "snp-density", "genome-tracks", "waterfall", "oncoplot", "motif-logo"].includes(type);
+  const hasLegend = !["box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "heatmap", "clustered-heatmap", "correlation-heatmap", "venn", "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos", "treemap", "manhattan", "qq", "chromosome-ideogram", "snp-density", "genome-tracks", "waterfall", "oncoplot", "motif-logo", "funnel", "precision-recall", "calibration", "decision-curve", "nomogram", "lasso-path", "km-cutoff", "risk-score"].includes(type);
   const compactRadialLegend = ["pie", "donut", "rose", "waffle", "sunburst", "radar", "polar-profile", "population-pyramid"].includes(type);
   const legend = hasLegend && settings.legendPosition === "right" ? (compactRadialLegend ? 110 : 145) : 0;
   if (heatmapType) return heatmapLayoutMetrics(settings, { hasAnnotationLegend: hasHeatmapAnnotationLegend, rowAnnotationTracks: 0, columnAnnotationTracks: 0, showRowCut: false, showColumnCut: false, showRowDendrogram: false, showColumnDendrogram: false, showSidePlot: false, rowCount: 1, columnCount: 1, maxColumnLabelCharacters: 0, maxCutClusters: 0 }).frame;
@@ -838,12 +839,40 @@ function ForestPlot({ frame, dataset, mapping, settings, colors, gridColor }: { 
 }
 
 function RocPlot({ frame, dataset, mapping, settings, colors, gridColor }: { frame: Frame; dataset: ParsedDataset; mapping: Record<string, string>; settings: VisualizationSettings; colors: string[]; gridColor: string }) {
-  const groups = [...new Set(dataset.rows.map((row) => mapping.group ? row[mapping.group] || "Model" : "Model"))];
-  const colorMap = palette(groups, colors);
   const xDomain = resolveAxisDomain([0, 1], settings.xMin, settings.xMax);
   const yDomain = resolveAxisDomain([0, 1], settings.yMin, settings.yMax);
   const xAt = (value: number) => scaleLinear(value, xDomain, [frame.left, frame.left + frame.plotWidth]);
   const yAt = (value: number) => scaleLinear(value, yDomain, [frame.top + frame.plotHeight, frame.top]);
+  if (settings.rocInputMode === "precomputed-time") {
+    const curveKeys = [...new Set(dataset.rows.map((row) => `${mapping.group ? row[mapping.group] || "Model" : "Model"}\u0000${parseNumericValue(row[mapping.horizon])}`))];
+    const curves = curveKeys.map((key, index) => {
+      const [group, horizon] = key.split("\u0000");
+      const rows = dataset.rows.filter((row) => (mapping.group ? row[mapping.group] || "Model" : "Model") === group && parseNumericValue(row[mapping.horizon]) === Number(horizon)).sort((a, b) => (parseNumericValue(a[mapping.fpr]) ?? 0) - (parseNumericValue(b[mapping.fpr]) ?? 0));
+      const first = rows[0];
+      return { key, group, horizon, color: categoricalColorForIndex(index, colors), rows, auc: parseNumericValue(first?.[mapping.auc]) ?? Number.NaN, aucLower: parseNumericValue(first?.[mapping.aucLower]) ?? Number.NaN, aucUpper: parseNumericValue(first?.[mapping.aucUpper]) ?? Number.NaN };
+    });
+    const compactProbability = (value: number) => value.toFixed(3).replace(/^0/, "");
+    const timeLegend = settings.legendPosition === "none" ? null : settings.legendPosition === "right"
+      ? <g data-plot-element="time-roc-legend" transform={`translate(${frame.left + frame.plotWidth + 18} ${frame.top + 5})`}>{curves.map((curve, index) => { const label = `${curve.group} · ${curve.horizon}`; return <g key={curve.key} transform={`translate(0 ${index * (settings.legendSize * 2 + 11)})`}><circle cx={4} cy={-4} r={4} fill={curve.color} /><text data-full-label={label} x={13} y={0} fill={TEXT} fontSize={settings.legendSize}><title>{label}</title>{compactLegendLabel(label, settings.legendSize, frame.width - (frame.left + frame.plotWidth + 35), 22)}</text><text data-auc-interval x={13} y={settings.legendSize + 4} fill={TEXT} fontSize={Math.max(8, settings.legendSize - 1)}>{`AUC ${compactProbability(curve.auc)} [${compactProbability(curve.aucLower)}–${compactProbability(curve.aucUpper)}]`}</text></g>; })}</g>
+      : <g data-plot-element="time-roc-legend" transform={`translate(${frame.left} ${frame.height - 68})`}>{curves.map((curve, index) => { const cellWidth = frame.plotWidth / 2; return <g key={curve.key} transform={`translate(${index % 2 * cellWidth} ${Math.floor(index / 2) * (settings.legendSize * 2 + 8)})`}><circle cx={4} cy={-4} r={4} fill={curve.color} /><text x={13} y={0} fill={TEXT} fontSize={settings.legendSize}>{compactLegendLabel(`${curve.group} · ${curve.horizon}`, settings.legendSize, cellWidth - 17, 18)}</text><text data-auc-interval x={13} y={settings.legendSize + 3} fill={TEXT} fontSize={Math.max(7, settings.legendSize - 2)}>{`AUC ${curve.auc.toFixed(2)} [${curve.aucLower.toFixed(2)}, ${curve.aucUpper.toFixed(2)}]`}</text></g>; })}</g>;
+    return <>
+      <Axes frame={frame} settings={settings} xDomain={xDomain} yDomain={yDomain} xLabel={settings.xLabel || "1 − specificity"} yLabel={settings.yLabel || "Sensitivity"} gridColor={gridColor} />
+      <g data-plot-data>
+        <line x1={xAt(0)} x2={xAt(1)} y1={yAt(0)} y2={yAt(1)} stroke="#9B9DA3" strokeDasharray="5 4" />
+        {curves.map((curve) => {
+          const upper = curve.rows.map((row) => `${xAt(parseNumericValue(row[mapping.fpr]) ?? 0)},${yAt(parseNumericValue(row[mapping.tprUpper]) ?? 0)}`);
+          const lower = [...curve.rows].reverse().map((row) => `${xAt(parseNumericValue(row[mapping.fpr]) ?? 0)},${yAt(parseNumericValue(row[mapping.tprLower]) ?? 0)}`);
+          return <g key={curve.key} data-plot-element="time-dependent-roc" data-model={curve.group} data-horizon={curve.horizon}>
+            <polygon points={[...upper, ...lower].join(" ")} fill={curve.color} fillOpacity={0.13} stroke="none"><title>Pointwise 95% confidence band supplied upstream</title></polygon>
+            <polyline points={curve.rows.map((row) => `${xAt(parseNumericValue(row[mapping.fpr]) ?? 0)},${yAt(parseNumericValue(row[mapping.tpr]) ?? 0)}`).join(" ")} fill="none" stroke={curve.color} strokeWidth={settings.dataLineWidth} />
+          </g>;
+        })}
+      </g>
+      {timeLegend}
+    </>;
+  }
+  const groups = [...new Set(dataset.rows.map((row) => mapping.group ? row[mapping.group] || "Model" : "Model"))];
+  const colorMap = palette(groups, colors);
   const curves = groups.map((group) => ({ group, ...rocCurve(dataset.rows.filter((row) => (mapping.group ? row[mapping.group] || "Model" : "Model") === group).map((row) => ({ truth: (parseNumericValue(row[mapping.truth]) === 1 ? 1 : 0) as 0 | 1, score: parseNumericValue(row[mapping.score]) ?? 0 }))) }));
   return <>
     <Axes frame={frame} settings={settings} xDomain={xDomain} yDomain={yDomain} xLabel={settings.xLabel || "1 − specificity"} yLabel={settings.yLabel || "Sensitivity"} gridColor={gridColor} />
@@ -1036,6 +1065,7 @@ export function ScientificAdvancedChartPreview({ svgRef, type, dataset, mapping,
   else if (type === "km") content = <KmPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (type === "survival-forest") content = <ForestPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (type === "roc") content = <RocPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
+  else if (["funnel", "precision-recall", "calibration", "decision-curve", "nomogram", "lasso-path", "km-cutoff", "risk-score"].includes(type)) content = <ScientificClinicalPlot type={type as ClinicalPlotType} frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} gridColor={theme.grid} />;
   else if (type === "venn" || type === "upset") content = <ScientificSetPlot type={type} frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} />;
   else if (type === "sankey") content = <SankeyPlot frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} />;
   else if (type === "alluvial") content = <ScientificFlowCircularPlot type="alluvial" frame={frame} dataset={dataset} mapping={mapping} settings={settings} colors={colors} />;

--- a/src/components/ScientificClinicalChartPreview.tsx
+++ b/src/components/ScientificClinicalChartPreview.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { calibrationBins, decisionCurve, precisionRecallCurve, type BinaryPrediction } from "@/lib/visualization-clinical";
+import { kaplanMeier } from "@/lib/visualization-advanced";
+import { categoricalColorForIndex, compactLegendLabel, estimateLegendTextWidth, formatTick, parseNumericValue, scaleLinear, type ParsedDataset, type VisualizationSettings } from "@/lib/visualization-studio";
+
+export type ClinicalPlotType = "funnel" | "precision-recall" | "calibration" | "decision-curve" | "nomogram" | "lasso-path" | "km-cutoff" | "risk-score";
+type Frame = { width: number; height: number; left: number; right: number; top: number; bottom: number; plotWidth: number; plotHeight: number };
+type Props = { type: ClinicalPlotType; frame: Frame; dataset: ParsedDataset; mapping: Record<string, string>; settings: VisualizationSettings; colors: string[]; gridColor: string };
+const TEXT = "#23242A";
+
+function axes(frame: Frame, settings: VisualizationSettings, xLabel: string, yLabel: string) {
+  const bottom = frame.top + frame.plotHeight;
+  return <g><line x1={frame.left} x2={frame.left + frame.plotWidth} y1={bottom} y2={bottom} stroke={TEXT} strokeWidth={settings.axisLineWidth} /><line x1={frame.left} x2={frame.left} y1={frame.top} y2={bottom} stroke={TEXT} strokeWidth={settings.axisLineWidth} />{xLabel ? <text x={frame.left + frame.plotWidth / 2} y={frame.height - 13} textAnchor="middle" fill={TEXT} fontSize={settings.axisLabelSize} fontWeight={600}>{xLabel}</text> : null}{yLabel ? <text transform={`translate(18 ${frame.top + frame.plotHeight / 2}) rotate(-90)`} textAnchor="middle" fill={TEXT} fontSize={settings.axisLabelSize} fontWeight={600}>{yLabel}</text> : null}</g>;
+}
+function numericAxes(frame: Frame, settings: VisualizationSettings, xDomain: [number, number], yDomain: [number, number], xLabel: string, yLabel: string, gridColor: string) {
+  const bottom = frame.top + frame.plotHeight;
+  const ticks = Array.from({ length: 5 }, (_, index) => index / 4);
+  return <g data-clinical-axes>{ticks.map((fraction) => {
+    const x = frame.left + fraction * frame.plotWidth;
+    const y = bottom - fraction * frame.plotHeight;
+    const xValue = xDomain[0] + fraction * (xDomain[1] - xDomain[0]);
+    const yValue = yDomain[0] + fraction * (yDomain[1] - yDomain[0]);
+    return <g key={fraction}>
+      {settings.grid !== "none" ? <line x1={frame.left} x2={frame.left + frame.plotWidth} y1={y} y2={y} stroke={gridColor} strokeWidth={settings.gridLineWidth} /> : null}
+      {settings.grid === "both" ? <line x1={x} x2={x} y1={frame.top} y2={bottom} stroke={gridColor} strokeWidth={settings.gridLineWidth} /> : null}
+      <text x={frame.left - 7} y={y + 4} textAnchor="end" fill={TEXT} fontSize={settings.tickSize}>{formatTick(yValue)}</text>
+      <text x={x} y={bottom + 17} textAnchor="middle" fill={TEXT} fontSize={settings.tickSize}>{formatTick(xValue)}</text>
+    </g>;
+  })}{axes(frame, settings, xLabel, yLabel)}</g>;
+}
+function binaryRows(dataset: ParsedDataset, mapping: Record<string, string>, group: string): BinaryPrediction[] { return dataset.rows.filter((row) => !mapping.group || (row[mapping.group] || "Model") === group).map((row) => ({ truth: parseNumericValue(row[mapping.truth]) === 1 ? 1 as const : 0 as const, score: parseNumericValue(row[mapping.score]) ?? 0 })); }
+function modelGroups(dataset: ParsedDataset, mapping: Record<string, string>) { return [...new Set(dataset.rows.map((row) => mapping.group ? row[mapping.group] || "Model" : "Model"))]; }
+function InlineModelLabel({ frame, settings, index, color, label }: { frame: Frame; settings: VisualizationSettings; index: number; color: string; label: string }) { return <text data-no-clip="true" data-full-label={label} x={frame.left + 8} y={frame.top + 15 + index * 15} fill={color} fontSize={settings.legendSize}><title>{label}</title>{compactLegendLabel(label, settings.legendSize, frame.plotWidth - 16, 42)}</text>; }
+
+function CurveAxes({ frame, settings, xLabel, yLabel, gridColor }: { frame: Frame; settings: VisualizationSettings; xLabel: string; yLabel: string; gridColor: string }) { const bottom = frame.top + frame.plotHeight; return <>{[0, .25, .5, .75, 1].map((value) => { const x = frame.left + frame.plotWidth * value; const y = bottom - frame.plotHeight * value; return <g key={value}><line x1={frame.left} x2={frame.left + frame.plotWidth} y1={y} y2={y} stroke={gridColor} /><text x={frame.left - 7} y={y + 4} textAnchor="end" fill={TEXT} fontSize={settings.tickSize}>{value}</text><text x={x} y={bottom + 17} textAnchor="middle" fill={TEXT} fontSize={settings.tickSize}>{value}</text></g>; })}{axes(frame, settings, xLabel, yLabel)}</>; }
+
+function PrecisionRecall({ frame, dataset, mapping, settings, colors, gridColor }: Omit<Props, "type">) { const groups = modelGroups(dataset, mapping); const x = (v: number) => frame.left + v * frame.plotWidth; const y = (v: number) => frame.top + (1 - v) * frame.plotHeight; return <><CurveAxes frame={frame} settings={settings} xLabel={settings.xLabel || "Recall (sensitivity)"} yLabel={settings.yLabel || "Precision (PPV)"} gridColor={gridColor} /><g data-plot-data>{groups.map((group, index) => { const result = precisionRecallCurve(binaryRows(dataset, mapping, group)); const color = categoricalColorForIndex(index, colors); const label = `${group}: AP ${result.auprc.toFixed(3)} · prevalence ${result.prevalence.toFixed(3)}`; return <g key={group} data-plot-element="pr-curve"><line x1={x(0)} x2={x(1)} y1={y(result.prevalence)} y2={y(result.prevalence)} stroke={color} strokeDasharray="3 4" opacity={0.45} /><polyline points={result.points.map((point) => `${x(point.recall)},${y(point.precision)}`).join(" ")} fill="none" stroke={color} strokeWidth={settings.dataLineWidth} /><InlineModelLabel frame={frame} settings={settings} index={index} color={color} label={label} /></g>; })}</g></>; }
+
+function Calibration({ frame, dataset, mapping, settings, colors, gridColor }: Omit<Props, "type">) {
+  const groups = modelGroups(dataset, mapping); const x = (value: number) => frame.left + value * frame.plotWidth; const y = (value: number) => frame.top + (1 - value) * frame.plotHeight;
+  return <><CurveAxes frame={frame} settings={settings} xLabel={settings.xLabel || "Mean predicted probability"} yLabel={settings.yLabel || "Observed event proportion"} gridColor={gridColor} /><g data-plot-data><line x1={x(0)} x2={x(1)} y1={y(0)} y2={y(1)} stroke="#777A80" strokeDasharray="5 4" />{groups.map((group, index) => {
+    const rows = binaryRows(dataset, mapping, group); const bins = calibrationBins(rows, settings.calibrationBinCount); const color = categoricalColorForIndex(index, colors);
+    return <g key={group} data-plot-element="calibration-series"><polyline points={bins.map((bin) => `${x(bin.predicted)},${y(bin.observed)}`).join(" ")} fill="none" stroke={color} strokeWidth={settings.dataLineWidth} />{bins.map((bin, binIndex) => <g key={binIndex}><line x1={x(bin.predicted)} x2={x(bin.predicted)} y1={y(bin.lower)} y2={y(bin.upper)} stroke={color} /><circle cx={x(bin.predicted)} cy={y(bin.observed)} r={settings.pointSize * 0.55} fill={color}><title>{`n=${bin.n}; Wilson 95% CI ${bin.lower.toFixed(3)}–${bin.upper.toFixed(3)}`}</title></circle></g>)}<InlineModelLabel frame={frame} settings={settings} index={index} color={color} label={`${group} · n=${rows.length} · ${bins.length} bins`} /></g>;
+  })}<text x={frame.left + frame.plotWidth - 4} y={frame.top + 13} textAnchor="end" fill="#777A80" fontSize={Math.max(7, settings.tickSize - 2)}>Ideal calibration</text></g></>;
+}
+
+function DecisionCurve({ frame, dataset, mapping, settings, colors, gridColor }: Omit<Props, "type">) {
+  const groups = modelGroups(dataset, mapping);
+  const thresholds: number[] = [];
+  for (let threshold = settings.decisionThresholdMinimum; threshold <= settings.decisionThresholdMaximum + settings.decisionThresholdStep * 0.25; threshold += settings.decisionThresholdStep) thresholds.push(Number(Math.min(threshold, settings.decisionThresholdMaximum).toFixed(6)));
+  if (thresholds.at(-1) !== settings.decisionThresholdMaximum) thresholds.push(settings.decisionThresholdMaximum);
+  const all = groups.map((group) => ({ group, rows: decisionCurve(binaryRows(dataset, mapping, group), thresholds) })); const values = all.flatMap((entry) => entry.rows.flatMap((row) => [row.model, row.all, 0]));
+  const xDomain: [number, number] = [settings.decisionThresholdMinimum, settings.decisionThresholdMaximum]; const yDomain: [number, number] = [Math.min(-0.05, ...values), Math.max(0.05, ...values)];
+  const x = (value: number) => scaleLinear(value, xDomain, [frame.left, frame.left + frame.plotWidth]); const y = (value: number) => scaleLinear(value, yDomain, [frame.top + frame.plotHeight, frame.top]);
+  return <>{numericAxes(frame, settings, xDomain, yDomain, settings.xLabel || "Threshold probability", settings.yLabel || "Net benefit", gridColor)}<g data-plot-data><line x1={x(settings.decisionThresholdMinimum)} x2={x(settings.decisionThresholdMaximum)} y1={y(0)} y2={y(0)} stroke="#777A80" />{all[0] ? <polyline data-plot-element="treat-all" points={all[0].rows.map((row) => `${x(row.threshold)},${y(row.all)}`).join(" ")} fill="none" stroke="#777A80" strokeDasharray="5 4" /> : null}{all.map((entry, index) => { const color = categoricalColorForIndex(index, colors); return <g key={entry.group}><polyline data-plot-element="decision-curve" points={entry.rows.map((row) => `${x(row.threshold)},${y(row.model)}`).join(" ")} fill="none" stroke={color} strokeWidth={settings.dataLineWidth} /><InlineModelLabel frame={frame} settings={settings} index={index} color={color} label={entry.group} /></g>; })}</g><text x={frame.left + frame.plotWidth - 4} y={y(0) - 5} textAnchor="end" fill="#777A80" fontSize={settings.tickSize}>Treat none</text><text x={frame.left + frame.plotWidth - 4} y={frame.top + 13} textAnchor="end" fill="#777A80" fontSize={Math.max(7, settings.tickSize - 2)}>Treat all · shared cohort</text><text data-no-clip="true" data-plot-element="decision-threshold-grid" x={frame.left} y={frame.top + frame.plotHeight + 31} fill={TEXT} fontSize={Math.max(7, settings.tickSize - 2)}>{`Grid ${settings.decisionThresholdMinimum.toFixed(3)}–${settings.decisionThresholdMaximum.toFixed(3)} · Δ ${settings.decisionThresholdStep.toFixed(3)} · ${thresholds.length} thresholds`}</text></>;
+}
+
+function Funnel({ frame, dataset, mapping, settings, colors, gridColor }: Omit<Props, "type">) {
+  const rows = dataset.rows.map((row) => ({ label: row[mapping.label], effect: parseNumericValue(row[mapping.estimate]) ?? 0, se: parseNumericValue(row[mapping.error]) ?? 1 }));
+  const weights = rows.map((row) => 1 / (row.se * row.se));
+  const reference = rows.reduce((sum, row, index) => sum + row.effect * weights[index], 0) / Math.max(1e-9, weights.reduce((a, b) => a + b, 0));
+  const effects = rows.flatMap((row) => [row.effect, reference - 1.96 * row.se, reference + 1.96 * row.se]);
+  const rawMinimum = Math.min(...effects); const rawMaximum = Math.max(...effects); const xPadding = Math.max(0.05, (rawMaximum - rawMinimum) * 0.04);
+  const xDomain: [number, number] = [rawMinimum - xPadding, rawMaximum + xPadding];
+  const maxPrecision = Math.max(...rows.map((row) => 1 / row.se));
+  const yDomain: [number, number] = [0, maxPrecision * 1.08];
+  const x = (value: number) => scaleLinear(value, xDomain, [frame.left, frame.left + frame.plotWidth]);
+  const y = (value: number) => scaleLinear(value, yDomain, [frame.top + frame.plotHeight, frame.top]);
+  const precisionSteps = Array.from({ length: 30 }, (_, index) => maxPrecision * index / 29).slice(1);
+  return <>
+    {numericAxes(frame, settings, xDomain, yDomain, settings.xLabel || "Effect estimate", settings.yLabel || "Precision (1 / SE)", gridColor)}
+    <g data-plot-data>
+      <line x1={x(reference)} x2={x(reference)} y1={y(0)} y2={y(maxPrecision)} stroke={TEXT} strokeDasharray="5 4" />
+      <polyline points={precisionSteps.map((precision) => `${x(reference - 1.96 / precision)},${y(precision)}`).join(" ")} fill="none" stroke="#8B8D92" />
+      <polyline points={precisionSteps.map((precision) => `${x(reference + 1.96 / precision)},${y(precision)}`).join(" ")} fill="none" stroke="#8B8D92" />
+      {rows.map((row, index) => <circle key={`${row.label}-${index}`} data-plot-element="funnel-study" cx={x(row.effect)} cy={y(1 / row.se)} r={settings.pointSize * 0.7} fill={colors[0]}><title>{`${row.label}: ${row.effect}; SE ${row.se}`}</title></circle>)}
+    </g>
+  </>;
+}
+
+function Nomogram({ frame, dataset, mapping, settings, colors }: Omit<Props, "type" | "gridColor">) {
+  const predictors = [...new Set(dataset.rows.map((row) => row[mapping.group]))]; const maximum = Math.max(...dataset.rows.map((row) => parseNumericValue(row[mapping.value]) ?? 0), 1); const rowGap = frame.plotHeight / Math.max(1, predictors.length); const scaleEnd = maximum * 1.03;
+  const x = (value: number) => scaleLinear(value, [0, scaleEnd], [frame.left + 70, frame.left + frame.plotWidth]);
+  return <g data-plot-data>{predictors.map((predictor, index) => { const rows = dataset.rows.filter((row) => row[mapping.group] === predictor); const y = frame.top + rowGap * (index + 0.5); return <g key={predictor}><text data-full-label={predictor} x={frame.left} y={y + 4} fill={TEXT} fontSize={settings.tickSize} fontWeight={700}><title>{predictor}</title>{compactLegendLabel(predictor, settings.tickSize, 62, 12)}</text><line x1={x(0)} x2={x(maximum)} y1={y} y2={y} stroke="#B7B8BC" />{rows.map((row, pointIndex) => { const points = parseNumericValue(row[mapping.value]) ?? 0; const label = row[mapping.label]; const labelFont = Math.max(7, settings.tickSize - 2); const compactLabel = compactLegendLabel(label, labelFont, 42, 10); const labelWidth = estimateLegendTextWidth(compactLabel, labelFont); const pointX = x(points); const labelX = Math.min(frame.left + frame.plotWidth - labelWidth / 2 - 2, Math.max(frame.left + 70 + labelWidth / 2 + 2, pointX)); return <g key={pointIndex}><circle data-plot-element="nomogram-point" cx={pointX} cy={y} r={settings.pointSize * 0.55} fill={categoricalColorForIndex(index, colors)} /><text data-full-label={label} x={labelX} y={y - 7} textAnchor="middle" fill={TEXT} fontSize={labelFont}><title>{label}</title>{compactLabel}</text></g>; })}</g>; })}<text x={frame.left + frame.plotWidth / 2} y={frame.height - 13} textAnchor="middle" fill={TEXT} fontSize={settings.axisLabelSize}>{settings.xLabel || "Assigned points (upstream model)"}</text></g>;
+}
+
+function LassoPath({ frame, dataset, mapping, settings, colors, gridColor }: Omit<Props, "type">) { const features = [...new Set(dataset.rows.map((row) => row[mapping.group]))]; const rows = dataset.rows.map((row) => ({ x: Math.log10(parseNumericValue(row[mapping.x]) ?? 1), y: parseNumericValue(row[mapping.y]) ?? 0, feature: row[mapping.group] })); const xs = rows.map((row) => row.x); const ys = rows.map((row) => row.y); const xd: [number, number] = [Math.min(...xs), Math.max(...xs)]; const yd: [number, number] = [Math.min(...ys), Math.max(...ys)]; const x = (v: number) => scaleLinear(v, xd, [frame.left, frame.left + frame.plotWidth]); const y = (v: number) => scaleLinear(v, yd, [frame.top + frame.plotHeight, frame.top]); const labelFont = Math.max(8, settings.legendSize - 1); const labelStep = labelFont + 3; return <>{numericAxes(frame, settings, xd, yd, settings.xLabel || "log₁₀(λ)", settings.yLabel || "Coefficient", gridColor)}<g data-plot-data>{features.map((feature, index) => <g key={feature} data-plot-element="lasso-path"><polyline points={rows.filter((row) => row.feature === feature).sort((a, b) => a.x - b.x).map((row) => `${x(row.x)},${y(row.y)}`).join(" ")} fill="none" stroke={categoricalColorForIndex(index, colors)} strokeWidth={settings.dataLineWidth}><title>{feature}</title></polyline><text data-full-label={feature} x={frame.left + 7} y={frame.top + labelFont + index * labelStep} fill={categoricalColorForIndex(index, colors)} fontSize={labelFont}><title>{feature}</title>{compactLegendLabel(feature, labelFont, frame.plotWidth - 14, 40)}</text></g>)}</g></>; }
+
+function CutoffKm({ frame, dataset, mapping, settings, colors, gridColor }: Omit<Props, "type">) {
+  const cutoff = parseNumericValue(dataset.rows[0]?.[mapping.cutoff]) ?? 0;
+  const groups = ["Low score", "High score"];
+  const curves = groups.map((group) => {
+    const observations = dataset.rows.filter((row) => ((parseNumericValue(row[mapping.score]) ?? 0) >= cutoff ? "High score" : "Low score") === group).map((row) => ({ time: parseNumericValue(row[mapping.time]) ?? 0, event: (parseNumericValue(row[mapping.event]) === 1 ? 1 : 0) as 0 | 1 }));
+    return { group, n: observations.length, points: kaplanMeier(observations) };
+  });
+  const maxTime = Math.max(...dataset.rows.map((row) => parseNumericValue(row[mapping.time]) ?? 0), 1);
+  const xDomain: [number, number] = [0, maxTime]; const yDomain: [number, number] = [0, 1];
+  const x = (value: number) => scaleLinear(value, xDomain, [frame.left, frame.left + frame.plotWidth]);
+  const y = (value: number) => scaleLinear(value, yDomain, [frame.top + frame.plotHeight, frame.top]);
+  return <>
+    {numericAxes(frame, settings, xDomain, yDomain, settings.xLabel || "Follow-up time", settings.yLabel || "Survival probability", gridColor)}
+    <g data-plot-data>{curves.map((curve, index) => {
+      const color = categoricalColorForIndex(index, colors);
+      const path = curve.points.slice(1).reduce((current, point) => `${current} H ${x(point.time)} V ${y(point.survival)}`, `M ${x(0)} ${y(1)}`);
+      return <g key={curve.group}>
+        <path data-plot-element="cutoff-km" data-step-curve="right-continuous" d={path} fill="none" stroke={color} strokeWidth={settings.dataLineWidth} />
+        {curve.points.filter((point) => point.censored > 0).map((point) => { const half = 3.5; const cx = x(point.time); const cy = y(point.survival); return <g key={point.time} data-plot-element="cutoff-km-censor" data-censored-count={point.censored} data-censor-time-x={cx} data-censor-survival-y={cy}><title>{`${point.censored} censored at time ${point.time}`}</title><line data-no-clip="true" x1={cx - half} x2={cx + half} y1={cy} y2={cy} stroke={color} strokeWidth={1.4} /><line data-no-clip="true" x1={cx} x2={cx} y1={cy - half} y2={cy + half} stroke={color} strokeWidth={1.4} /></g>; })}
+        <text data-no-clip="true" data-full-label={curve.group} x={frame.left + 8} y={frame.top + 15 + index * 15} fill={color} fontSize={settings.legendSize}>{`${curve.group} · n=${curve.n}`}</text>
+      </g>;
+    })}</g>
+    <g data-no-clip="true" fill={TEXT} fontSize={Math.max(7, settings.tickSize - 2)}><text x={frame.left} y={frame.top + frame.plotHeight + 31}>{`Supplied cutoff = ${cutoff} · upstream threshold.`}</text><text x={frame.left} y={frame.top + frame.plotHeight + 43}>Independent validation required.<title>Optimization and evaluation in the same cohort is exploratory and optimistic.</title></text></g>
+  </>;
+}
+
+function RiskScore({ frame, dataset, mapping, settings, colors }: Omit<Props, "type" | "gridColor">) { const rows = dataset.rows.map((row) => ({ sample: row[mapping.label], score: parseNumericValue(row[mapping.score]) ?? 0, outcome: parseNumericValue(row[mapping.truth]) === 1 ? 1 : 0 })).sort((a, b) => a.score - b.score); const domain: [number, number] = [Math.min(...rows.map((row) => row.score)), Math.max(...rows.map((row) => row.score))]; const scoreBottom = frame.top + frame.plotHeight * .72; const x = (index: number) => frame.left + frame.plotWidth * (index + .5) / Math.max(1, rows.length); const y = (value: number) => scaleLinear(value, domain, [scoreBottom, frame.top]); return <>{axes(frame, settings, settings.xLabel || "Subjects ranked by score", settings.yLabel || "Risk score")}<g data-plot-data>{rows.map((row, index) => <g key={`${row.sample}-${index}`} data-plot-element="risk-subject"><line x1={x(index)} x2={x(index)} y1={scoreBottom} y2={y(row.score)} stroke={categoricalColorForIndex(row.outcome, colors)} strokeWidth={Math.max(1, settings.dataLineWidth * .7)} /><circle cx={x(index)} cy={y(row.score)} r={Math.max(1.5, settings.pointSize * .35)} fill={categoricalColorForIndex(row.outcome, colors)} /><rect x={x(index) - 2} y={scoreBottom + 18} width={4} height={12} fill={categoricalColorForIndex(row.outcome, colors)}><title>{`${row.sample}; outcome=${row.outcome}; score=${row.score}`}</title></rect></g>)}</g><g data-plot-element="risk-outcome-legend" transform={`translate(${frame.left + frame.plotWidth - 102} ${frame.top + 7})`} fontSize={Math.max(8, settings.legendSize - 1)} fill={TEXT}><rect x={0} y={-7} width={8} height={8} fill={categoricalColorForIndex(0, colors)} /><text x={12} y={0}>Outcome 0</text><rect x={58} y={-7} width={8} height={8} fill={categoricalColorForIndex(1, colors)} /><text x={70} y={0}>1</text></g><text x={frame.left} y={scoreBottom + 44} fill={TEXT} fontSize={Math.max(7, settings.tickSize - 2)}>Descriptive ranking · not model validation.</text></>; }
+
+export function ScientificClinicalPlot(props: Props) { if (props.type === "funnel") return <Funnel {...props} />; if (props.type === "precision-recall") return <PrecisionRecall {...props} />; if (props.type === "calibration") return <Calibration {...props} />; if (props.type === "decision-curve") return <DecisionCurve {...props} />; if (props.type === "nomogram") return <Nomogram {...props} />; if (props.type === "lasso-path") return <LassoPath {...props} />; if (props.type === "km-cutoff") return <CutoffKm {...props} />; return <RiskScore {...props} />; }

--- a/src/components/VisualizationStudio.tsx
+++ b/src/components/VisualizationStudio.tsx
@@ -571,7 +571,9 @@ export function VisualizationStudio() {
     setSelectedIntersectionSignature("");
     if (plotType === "pca") setPcaOptions(defaultPcaOptions);
     if (plotType === "bar") updateSetting("barInputMode", exampleIndex === 1 ? "long" : "summary");
+    if (plotType === "roc") updateSetting("rocInputMode", exampleIndex === 1 ? "precomputed-time" : "raw");
     if (plotType === "venn" || plotType === "upset") updateSetting("setInputMode", exampleIndex === 1 ? "peak-overlap" : "membership");
+    if (example.settings) setSettings((current) => ({ ...current, ...example.settings as Partial<VisualizationSettings> }));
   };
 
   const selectPlot = (nextType: PlotType) => {
@@ -599,6 +601,7 @@ export function VisualizationStudio() {
       heatmapColumnClusters: nextType === "correlation-heatmap" ? current.heatmapRowClusters : current.heatmapColumnClusters,
       compositionLabelMode: nextType === "rose" ? "value" : current.compositionLabelMode,
       setInputMode: (nextType === "venn" || nextType === "upset") ? "membership" : current.setInputMode,
+      rocInputMode: nextType === "roc" ? "raw" : current.rocInputMode,
       legendPosition: (["heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment", "enrichment-bar", "venn", "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos"] as PlotType[]).includes(nextType) && current.legendPosition === "bottom" ? "right" : current.legendPosition,
     }, nextType));
     window.requestAnimationFrame(() => {
@@ -1048,6 +1051,15 @@ export function VisualizationStudio() {
               {setAnalysis && setAnalysis.intersections.length > 0 ? <><SelectControl label="Exact intersection to download" value={selectedSetIntersection?.signature ?? ""} onChange={setSelectedIntersectionSignature}>{setAnalysis.intersections.map((entry) => <option key={entry.signature} value={entry.signature}>{entry.sets.join(" ∩ ")} · n={entry.size}</option>)}</SelectControl><Button type="button" variant="secondary" size="sm" className="w-full justify-center" onClick={downloadSelectedIntersection}><Download className="h-3.5 w-3.5" aria-hidden />Download selected members</Button></> : null}
               <p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Counts are exact membership combinations. Peak mode splits half-open intervals [start, end) into disjoint atomic genomic segments wherever active set membership changes; counts are segments, not base pairs or original peaks. Size weighting is only a visual cue, never an area-proportional fit.</p>
             </ControlGroup> : null}
+
+            {plotType === "roc" ? <ControlGroup title="ROC input">
+              <SelectControl label="Input structure" value={settings.rocInputMode} onChange={(value) => updateSetting("rocInputMode", value as VisualizationSettings["rocInputMode"])}><option value="raw">Raw binary outcomes + scores</option><option value="precomputed-time">Time-dependent coordinates + 95% CI</option></SelectControl>
+              <p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Raw mode computes empirical ROC and trapezoidal AUC per model. Time-dependent mode only displays censoring-aware coordinates, pointwise TPR intervals, horizons, and AUC intervals supplied by a documented upstream method; it never infers them from ordinary binary scores.</p>
+            </ControlGroup> : null}
+
+            {plotType === "calibration" ? <ControlGroup title="Calibration grouping"><RangeControl label="Equal-frequency bins" value={settings.calibrationBinCount} minimum={3} maximum={15} step={1} onChange={(value) => updateSetting("calibrationBinCount", value)} /><p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Subjects are sorted by predicted probability and divided into approximately equal-frequency bins separately for each model. Fewer bins are more stable in small cohorts.</p></ControlGroup> : null}
+
+            {plotType === "decision-curve" ? <ControlGroup title="Decision thresholds"><RangeControl label="Minimum threshold" value={settings.decisionThresholdMinimum} minimum={0.005} maximum={0.5} step={0.005} onChange={(value) => updateSetting("decisionThresholdMinimum", value)} /><RangeControl label="Maximum threshold" value={settings.decisionThresholdMaximum} minimum={0.05} maximum={0.99} step={0.01} onChange={(value) => updateSetting("decisionThresholdMaximum", value)} /><RangeControl label="Grid resolution" value={settings.decisionThresholdStep} minimum={0.005} maximum={0.05} step={0.005} onChange={(value) => updateSetting("decisionThresholdStep", value)} /><p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Net benefit is evaluated only on the displayed threshold grid. Choose a clinically meaningful interval; a grid step ≤0.01 is recommended when narrow utility regions matter.</p></ControlGroup> : null}
 
             {plotType === "line" || (plotType === "bar" && !["stacked", "percentage", "polar"].includes(settings.barVariant)) ? <ControlGroup title={`${plotType === "bar" ? "Bar" : "Line"} uncertainty`}>
               <SelectControl label="Error representation" value={plotType === "bar" ? settings.barErrorType : settings.lineErrorType} onChange={(value) => selectErrorType(plotType === "bar" ? "barErrorType" : "lineErrorType", value as VisualizationSettings["barErrorType"] | VisualizationSettings["lineErrorType"])}><option value="none">None</option><option value="sd">Mean ± SD</option><option value="sem">Mean ± SEM</option>{plotType === "line" ? <option value="ci95">95% CI half-width</option> : null}</SelectControl>

--- a/src/lib/plot-module-registry.test.ts
+++ b/src/lib/plot-module-registry.test.ts
@@ -77,7 +77,7 @@ describe("plot-module registry interface", () => {
   });
 
   it("adapts all existing plots to the shared module contract", () => {
-    expect(plotModuleRegistry.list()).toHaveLength(63);
+    expect(plotModuleRegistry.list()).toHaveLength(71);
     plotModuleRegistry.list().forEach((plotModule) => {
       expect(plotModule.definition.id).toBeTruthy();
       expect(plotModule.examples.length).toBeGreaterThan(0);

--- a/src/lib/plot-module-registry.ts
+++ b/src/lib/plot-module-registry.ts
@@ -3,7 +3,7 @@ export type PlotRendererId = "standard" | "advanced";
 export type PlotDataShape = "long" | "matrix" | "coordinates" | "sets" | "network" | "hierarchy" | "genomic-links" | "genomic-coordinates" | "alterations" | "motif-matrix";
 
 type PlotRoleLike = { key: string; label: string; kind: "category" | "number" | "label"; required: boolean };
-type PlotExampleLike = { label: string; description: string; data: string; metadata?: string; mapping?: Record<string, string> };
+type PlotExampleLike = { label: string; description: string; data: string; metadata?: string; mapping?: Record<string, string>; settings?: Record<string, unknown> };
 type PlotDefinitionLike<PlotId extends string> = {
   id: PlotId;
   name: string;

--- a/src/lib/plot-module-rendering.test.tsx
+++ b/src/lib/plot-module-rendering.test.tsx
@@ -15,6 +15,7 @@ import {
 const expectedAdvancedRenderers = new Set([
   "line", "scatter", "correlation", "pca", "pcoa", "umap", "tsne", "nmds", "box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "ma", "quadrant", "errorbar", "area", "lollipop",
   "heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment-bar", "gsea", "km", "survival-forest", "roc", "venn",
+  "funnel", "precision-recall", "calibration", "decision-curve", "nomogram", "lasso-path", "km-cutoff", "risk-score",
   "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos",
   "network", "ppi", "cerna", "mirna-target", "cnet", "enrichment-map", "tree", "dendrogram",
   "manhattan", "qq", "chromosome-ideogram", "snp-density", "genome-tracks", "waterfall", "oncoplot", "motif-logo",
@@ -32,7 +33,8 @@ describe("registered plot-module examples", () => {
         const mappings = analysis || example.mapping === undefined ? [selectedMapping] : [selectedMapping, inferredMapping];
 
         for (const mapping of mappings) {
-          const validation = validatePlotDataset(plotModule.definition, dataset, mapping, defaultVisualizationSettings);
+          const settings = { ...defaultVisualizationSettings, ...example.settings } as typeof defaultVisualizationSettings;
+          const validation = validatePlotDataset(plotModule.definition, dataset, mapping, settings);
           expect(validation.errors, `${plotModule.definition.id} / ${example.label}`).toEqual([]);
 
           const markup = renderToStaticMarkup(
@@ -41,7 +43,7 @@ describe("registered plot-module examples", () => {
               type={plotModule.definition.id}
               dataset={dataset}
               mapping={mapping}
-              settings={defaultVisualizationSettings}
+              settings={settings}
               themeId={defaultVisualizationThemeId}
             />,
           );

--- a/src/lib/visualization-advanced.ts
+++ b/src/lib/visualization-advanced.ts
@@ -215,18 +215,20 @@ export type KaplanMeierPoint = { time: number; survival: number; atRisk: number;
 
 export function kaplanMeier(records: Array<{ time: number; event: 0 | 1 }>) {
   const ordered = [...records].sort((a, b) => a.time - b.time || b.event - a.event);
-  const times = [...new Set(ordered.map((record) => record.time))];
   const points: KaplanMeierPoint[] = [{ time: 0, survival: 1, atRisk: ordered.length, events: 0, censored: 0 }];
   let survival = 1;
   let atRisk = ordered.length;
-  times.forEach((time) => {
-    const recordsAtTime = ordered.filter((record) => record.time === time);
-    const events = recordsAtTime.filter((record) => record.event === 1).length;
-    const censored = recordsAtTime.length - events;
+  for (let start = 0; start < ordered.length;) {
+    const time = ordered[start].time;
+    let end = start; let events = 0;
+    while (end < ordered.length && ordered[end].time === time) { if (ordered[end].event === 1) events += 1; end += 1; }
+    const countAtTime = end - start;
+    const censored = countAtTime - events;
     if (atRisk > 0 && events > 0) survival *= 1 - events / atRisk;
     points.push({ time, survival, atRisk, events, censored });
-    atRisk -= recordsAtTime.length;
-  });
+    atRisk -= countAtTime;
+    start = end;
+  }
   return points;
 }
 
@@ -236,14 +238,15 @@ export function rocCurve(records: Array<{ truth: 0 | 1; score: number }>) {
   const positives = records.filter((record) => record.truth === 1).length;
   const negatives = records.length - positives;
   if (positives === 0 || negatives === 0) return { points: [] as RocPoint[], auc: Number.NaN };
-  const thresholds = [Number.POSITIVE_INFINITY, ...[...new Set(records.map((record) => record.score))].sort((a, b) => b - a), Number.NEGATIVE_INFINITY];
-  const points = thresholds.map((threshold) => {
-    const predictedPositive = records.filter((record) => record.score >= threshold);
-    const truePositive = predictedPositive.filter((record) => record.truth === 1).length;
-    const falsePositive = predictedPositive.length - truePositive;
-    return { fpr: falsePositive / negatives, tpr: truePositive / positives, threshold };
-  });
-  const unique = points.filter((point, index) => index === 0 || point.fpr !== points[index - 1].fpr || point.tpr !== points[index - 1].tpr);
+  const ordered = [...records].sort((a, b) => b.score - a.score);
+  const unique: RocPoint[] = [{ fpr: 0, tpr: 0, threshold: Number.POSITIVE_INFINITY }];
+  let truePositive = 0; let falsePositive = 0;
+  for (let start = 0; start < ordered.length;) {
+    const threshold = ordered[start].score; let end = start;
+    while (end < ordered.length && ordered[end].score === threshold) { if (ordered[end].truth === 1) truePositive += 1; else falsePositive += 1; end += 1; }
+    unique.push({ fpr: falsePositive / negatives, tpr: truePositive / positives, threshold });
+    start = end;
+  }
   const auc = unique.slice(1).reduce((sum, point, index) => {
     const previous = unique[index];
     return sum + (point.fpr - previous.fpr) * (point.tpr + previous.tpr) / 2;

--- a/src/lib/visualization-clinical.test.ts
+++ b/src/lib/visualization-clinical.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { calibrationBins, decisionCurve, precisionRecallCurve } from "./visualization-clinical";
+import { kaplanMeier, rocCurve } from "./visualization-advanced";
+import { defaultVisualizationSettings, getPlotDefinition, getPlotModule, parseDelimitedData, validatePlotDataset } from "./visualization-studio";
+
+describe("clinical evaluation calculations", () => {
+  it("computes average precision from recall increments and reports prevalence", () => {
+    const result = precisionRecallCurve([
+      { truth: 1, score: 0.9 },
+      { truth: 0, score: 0.8 },
+      { truth: 1, score: 0.7 },
+      { truth: 0, score: 0.1 },
+    ]);
+    expect(result.auprc).toBeCloseTo(5 / 6, 8);
+    expect(result.prevalence).toBe(0.5);
+    expect(result.points.at(-1)).toEqual({ recall: 1, precision: 0.5 });
+  });
+
+  it("treats tied scores as one threshold and is invariant to tie order", () => {
+    const first = [{ truth: 1 as const, score: 0.8 }, { truth: 0 as const, score: 0.8 }, { truth: 1 as const, score: 0.4 }, { truth: 0 as const, score: 0.2 }];
+    const reordered = [first[1], first[0], first[2], first[3]];
+    expect(precisionRecallCurve(first)).toEqual(precisionRecallCurve(reordered));
+    expect(precisionRecallCurve(first).points).toHaveLength(4);
+  });
+
+  it("uses equal-frequency calibration groups with ordered Wilson intervals", () => {
+    const rows = Array.from({ length: 24 }, (_, index) => ({
+      truth: (index % 3 === 0 ? 1 : 0) as 0 | 1,
+      score: (index + 0.5) / 24,
+    }));
+    const bins = calibrationBins(rows, 6);
+    expect(bins).toHaveLength(6);
+    expect(bins.every((bin) => bin.n === 4)).toBe(true);
+    expect(bins.every((bin) => bin.lower <= bin.observed && bin.observed <= bin.upper)).toBe(true);
+    expect(bins.every((bin, index) => index === 0 || bin.predicted > bins[index - 1].predicted)).toBe(true);
+  });
+
+  it("never splits tied probabilities across calibration bins", () => {
+    const rows = [{ truth: 1 as const, score: 0.2 }, { truth: 0 as const, score: 0.2 }, { truth: 1 as const, score: 0.2 }, { truth: 0 as const, score: 0.7 }, { truth: 1 as const, score: 0.9 }, { truth: 0 as const, score: 0.9 }];
+    const reordered = [rows[2], rows[0], rows[1], rows[5], rows[3], rows[4]];
+    expect(calibrationBins(rows, 3)).toEqual(calibrationBins(reordered, 3));
+    expect(calibrationBins(rows, 3).map((bin) => bin.n)).toEqual([3, 3]);
+  });
+
+  it("computes standard decision-curve net benefit and reference strategies", () => {
+    const rows = [
+      { truth: 1 as const, score: 0.9 },
+      { truth: 1 as const, score: 0.8 },
+      { truth: 0 as const, score: 0.7 },
+      { truth: 0 as const, score: 0.1 },
+    ];
+    const [point] = decisionCurve(rows, [0.5]);
+    expect(point.model).toBeCloseTo(0.25, 8);
+    expect(point.all).toBeCloseTo(0, 8);
+    expect(point.none).toBe(0);
+  });
+});
+
+describe("clinical input contracts", () => {
+  it("requires both outcomes inside every raw prediction model", () => {
+    const dataset = parseDelimitedData("truth\tscore\tmodel\n1\t0.9\tA\n0\t0.2\tA\n1\t0.8\tB\n1\t0.6\tB");
+    const validation = validatePlotDataset(getPlotDefinition("precision-recall"), dataset, { truth: "truth", score: "score", group: "model" }, defaultVisualizationSettings);
+    expect(validation.errors).toContain("Precision–recall model “B” requires both observed outcome classes (0 and 1).");
+  });
+
+  it("blocks unordered time-dependent ROC uncertainty", () => {
+    const dataset = parseDelimitedData("fpr\ttpr\ttpr_lower\ttpr_upper\thorizon\tgroup\tauc\tauc_lower\tauc_upper\n0\t0\t0\t0\t12\tModel\t0.75\t0.70\t0.80\n0.5\t0.8\t0.85\t0.9\t12\tModel\t0.75\t0.70\t0.80\n1\t1\t1\t1\t12\tModel\t0.75\t0.70\t0.80");
+    const validation = validatePlotDataset(getPlotDefinition("roc"), dataset, { truth: "", score: "", group: "group", fpr: "fpr", tpr: "tpr", tprLower: "tpr_lower", tprUpper: "tpr_upper", horizon: "horizon", auc: "auc", aucLower: "auc_lower", aucUpper: "auc_upper" }, { ...defaultVisualizationSettings, rocInputMode: "precomputed-time" });
+    expect(validation.errors.some((error) => /unordered TPR or AUC/.test(error))).toBe(true);
+  });
+
+  it("canonicalizes numerically equivalent time horizons", () => {
+    const dataset = parseDelimitedData("fpr\ttpr\ttpr_lower\ttpr_upper\thorizon\tgroup\tauc\tauc_lower\tauc_upper\n0\t0\t0\t0\t12\tModel\t0.75\t0.70\t0.80\n0.5\t0.8\t0.7\t0.9\t12.0\tModel\t0.75\t0.70\t0.80\n1\t1\t1\t1\t12.00\tModel\t0.75\t0.70\t0.80");
+    const validation = validatePlotDataset(getPlotDefinition("roc"), dataset, { truth: "", score: "", group: "group", fpr: "fpr", tpr: "tpr", tprLower: "tpr_lower", tprUpper: "tpr_upper", horizon: "horizon", auc: "auc", aucLower: "auc_lower", aucUpper: "auc_upper" }, { ...defaultVisualizationSettings, rocInputMode: "precomputed-time" });
+    expect(validation.errors).toEqual([]);
+  });
+
+  it("requires a shared subject-outcome cohort for multi-model decision curves", () => {
+    const dataset = parseDelimitedData("sample\ttruth\tscore\tmodel\nS1\t1\t0.8\tA\nS1\t0\t0.7\tB\nS2\t0\t0.2\tA\nS2\t0\t0.3\tB");
+    const validation = validatePlotDataset(getPlotDefinition("decision-curve"), dataset, { subject: "sample", truth: "truth", score: "score", group: "model" }, defaultVisualizationSettings);
+    expect(validation.errors).toContain("Subject “S1” has inconsistent observed outcomes across decision-curve models.");
+  });
+
+  it("validates an explicit decision-threshold interval and grid resolution", () => {
+    const dataset = parseDelimitedData("sample\ttruth\tscore\nS1\t1\t0.8\nS2\t0\t0.2");
+    const definition = getPlotDefinition("decision-curve");
+    const mapping = { subject: "sample", truth: "truth", score: "score", group: "" };
+    expect(validatePlotDataset(definition, dataset, mapping, { ...defaultVisualizationSettings, decisionThresholdMinimum: 0.01, decisionThresholdMaximum: 0.9, decisionThresholdStep: 0.01 }).errors).toEqual([]);
+    expect(validatePlotDataset(definition, dataset, mapping, { ...defaultVisualizationSettings, decisionThresholdMinimum: 0.6, decisionThresholdMaximum: 0.5 }).errors.some((error) => /0 < minimum < maximum < 1/.test(error))).toBe(true);
+    expect(validatePlotDataset(definition, dataset, mapping, { ...defaultVisualizationSettings, decisionThresholdStep: 0.1 }).errors.some((error) => /resolution must be between/.test(error))).toBe(true);
+  });
+
+  it("rejects blank shared-cohort IDs and duplicate risk-score subjects", () => {
+    const decision = parseDelimitedData("sample\ttruth\tscore\tmodel\n\t1\t0.8\tA\n\t1\t0.7\tB");
+    expect(validatePlotDataset(getPlotDefinition("decision-curve"), decision, { subject: "sample", truth: "truth", score: "score", group: "model" }, defaultVisualizationSettings).errors.some((error) => /blank value/.test(error))).toBe(true);
+    const risk = parseDelimitedData("sample\tscore\toutcome\nS1\t0.2\t0\nS1\t0.8\t1");
+    expect(validatePlotDataset(getPlotDefinition("risk-score"), risk, { label: "sample", score: "score", truth: "outcome" }, defaultVisualizationSettings).errors.some((error) => /must be unique/.test(error))).toBe(true);
+  });
+
+  it("requires complete unique LASSO paths on a common lambda grid", () => {
+    const dataset = parseDelimitedData("lambda\tcoefficient\tfeature\n1\t0\tA\n1\t0.1\tA\n0.5\t0.2\tB\n0.1\t0.4\tB");
+    const errors = validatePlotDataset(getPlotDefinition("lasso-path"), dataset, { x: "lambda", y: "coefficient", group: "feature" }, defaultVisualizationSettings).errors;
+    expect(errors.some((error) => /feature × lambda pair must be unique/.test(error))).toBe(true);
+    expect(errors.some((error) => /same lambda grid/.test(error))).toBe(true);
+  });
+
+  it("blocks ROC domains that would crop endpoints or confidence bands", () => {
+    const dataset = parseDelimitedData("truth\tscore\n1\t0.9\n0\t0.1");
+    const validation = validatePlotDataset(getPlotDefinition("roc"), dataset, { truth: "truth", score: "score", group: "" }, { ...defaultVisualizationSettings, xMin: 0.1 });
+    expect(validation.errors.some((error) => /must contain the full \[0, 1\]/.test(error))).toBe(true);
+  });
+
+  it("blocks colliding nomogram level labels", () => {
+    const dataset = parseDelimitedData("predictor\tlevel\tpoints\nStage\tLevel alpha\t10\nStage\tLevel beta\t10.1");
+    const validation = validatePlotDataset(getPlotDefinition("nomogram"), dataset, { group: "predictor", label: "level", value: "points" }, defaultVisualizationSettings);
+    expect(validation.errors.some((error) => /overlap within predictor/.test(error))).toBe(true);
+  });
+
+  it("does not expose ignored manual limits and does expose scientific controls", () => {
+    expect(getPlotModule("funnel").capabilities.settingKeys).not.toContain("xMin");
+    expect(getPlotModule("calibration").capabilities.settingKeys).toContain("calibrationBinCount");
+    expect(getPlotModule("decision-curve").capabilities.settingKeys).toContain("decisionThresholdMaximum");
+    expect(getPlotModule("decision-curve").capabilities.settingKeys).toContain("decisionThresholdMinimum");
+    expect(getPlotModule("decision-curve").capabilities.settingKeys).toContain("decisionThresholdStep");
+  });
+
+  it("handles many unique scores and follow-up times with sorting sweeps", () => {
+    const records = Array.from({ length: 10_000 }, (_, index) => ({ truth: (index % 2) as 0 | 1, score: index / 10_000 }));
+    expect(rocCurve(records).points).toHaveLength(10_001);
+    expect(kaplanMeier(records.map((record, index) => ({ time: index + 1, event: record.truth })))).toHaveLength(10_001);
+  });
+});

--- a/src/lib/visualization-clinical.ts
+++ b/src/lib/visualization-clinical.ts
@@ -1,0 +1,42 @@
+import { rocCurve } from "./visualization-advanced";
+
+export type BinaryPrediction = { truth: 0 | 1; score: number };
+
+export function precisionRecallCurve(rows: BinaryPrediction[]) {
+  const sorted = [...rows].sort((a, b) => b.score - a.score); const positives = rows.filter((row) => row.truth === 1).length;
+  let tp = 0; let fp = 0; const points = [{ recall: 0, precision: 1 }];
+  for (let start = 0; start < sorted.length;) {
+    let end = start + 1;
+    while (end < sorted.length && sorted[end].score === sorted[start].score) end += 1;
+    for (let index = start; index < end; index += 1) { if (sorted[index].truth === 1) tp += 1; else fp += 1; }
+    points.push({ recall: positives ? tp / positives : 0, precision: tp / Math.max(1, tp + fp) });
+    start = end;
+  }
+  let auprc = 0; for (let index = 1; index < points.length; index += 1) auprc += (points[index].recall - points[index - 1].recall) * points[index].precision;
+  return { points, auprc, prevalence: rows.length ? positives / rows.length : 0 };
+}
+
+export function calibrationBins(rows: BinaryPrediction[], binCount = 8) {
+  const sorted = [...rows].sort((a, b) => a.score - b.score); const bins: Array<{ predicted: number; observed: number; lower: number; upper: number; n: number }> = [];
+  const targetSize = Math.max(1, Math.ceil(sorted.length / binCount));
+  for (let start = 0; start < sorted.length;) {
+    let end = Math.min(sorted.length, start + targetSize);
+    while (end < sorted.length && sorted[end].score === sorted[end - 1].score) end += 1;
+    const bin = sorted.slice(start, end); const n = bin.length;
+    const predicted = bin.reduce((sum, row) => sum + row.score, 0) / n; const observed = bin.reduce((sum, row) => sum + row.truth, 0) / n;
+    const z = 1.96; const denominator = 1 + z * z / n; const center = (observed + z * z / (2 * n)) / denominator; const half = z * Math.sqrt(observed * (1 - observed) / n + z * z / (4 * n * n)) / denominator;
+    bins.push({ predicted, observed, lower: Math.max(0, center - half), upper: Math.min(1, center + half), n });
+    start = end;
+  }
+  return bins;
+}
+
+export function decisionCurve(rows: BinaryPrediction[], thresholds = Array.from({ length: 16 }, (_, index) => 0.05 + index * 0.05)) {
+  const n = Math.max(1, rows.length); const prevalence = rows.filter((row) => row.truth === 1).length / n;
+  return thresholds.map((threshold) => {
+    const selected = rows.filter((row) => row.score >= threshold); const tp = selected.filter((row) => row.truth === 1).length; const fp = selected.length - tp; const odds = threshold / (1 - threshold);
+    return { threshold, model: tp / n - fp / n * odds, all: prevalence - (1 - prevalence) * odds, none: 0 };
+  });
+}
+
+export function binaryRoc(rows: BinaryPrediction[]) { return rocCurve(rows); }

--- a/src/lib/visualization-studio.test.ts
+++ b/src/lib/visualization-studio.test.ts
@@ -110,11 +110,12 @@ describe("Visualization Studio data contracts", () => {
       "scatter", "correlation", "volcano", "ma", "quadrant", "bar", "errorbar", "line", "area", "lollipop",
       "box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "clustered-heatmap", "correlation-heatmap", "pca", "pcoa", "umap", "tsne", "nmds",
       "enrichment", "enrichment-bar", "gsea", "km", "survival-forest", "roc", "venn", "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos",
+      "funnel", "precision-recall", "calibration", "decision-curve", "nomogram", "lasso-path", "km-cutoff", "risk-score",
       "manhattan", "qq", "chromosome-ideogram", "snp-density", "genome-tracks", "waterfall", "oncoplot", "motif-logo",
       "network", "ppi", "cerna", "mirna-target", "cnet", "enrichment-map", "tree", "dendrogram",
       "pie", "donut", "rose", "waffle", "treemap", "sunburst", "radar", "polar-profile", "population-pyramid",
     ];
-    expect(plotDefinitions).toHaveLength(63);
+    expect(plotDefinitions).toHaveLength(71);
     expect(requested.every((id) => plotDefinitions.some((definition) => definition.id === id && definition.sampleData.length > 20))).toBe(true);
     plotDefinitions.forEach((definition) => {
       const examples = getPlotExamples(definition);

--- a/src/lib/visualization-studio.ts
+++ b/src/lib/visualization-studio.ts
@@ -76,6 +76,14 @@ export type PlotType =
   | "km"
   | "survival-forest"
   | "roc"
+  | "funnel"
+  | "precision-recall"
+  | "calibration"
+  | "decision-curve"
+  | "nomogram"
+  | "lasso-path"
+  | "km-cutoff"
+  | "risk-score"
   | "venn"
   | "upset"
   | "sankey"
@@ -185,6 +193,7 @@ export type PlotDataExample = {
   data: string;
   mapping?: Record<string, string>;
   metadata?: string;
+  settings?: Partial<VisualizationSettings>;
 };
 
 export type PlotReference = {
@@ -349,6 +358,11 @@ export type VisualizationSettings = {
   networkEdgeOpacity: number;
   treeOrientation: "vertical" | "horizontal";
   setInputMode: "auto" | "membership" | "peak-overlap";
+  rocInputMode: "raw" | "precomputed-time";
+  calibrationBinCount: number;
+  decisionThresholdMinimum: number;
+  decisionThresholdMaximum: number;
+  decisionThresholdStep: number;
   vennLayout: "auto" | "classic" | "radial";
   vennProportional: boolean;
   upsetMaxIntersections: number;
@@ -482,6 +496,11 @@ export const defaultVisualizationSettings: VisualizationSettings = {
   networkEdgeOpacity: 0.62,
   treeOrientation: "vertical",
   setInputMode: "auto",
+  rocInputMode: "raw",
+  calibrationBinCount: 8,
+  decisionThresholdMinimum: 0.05,
+  decisionThresholdMaximum: 0.8,
+  decisionThresholdStep: 0.01,
   vennLayout: "auto",
   vennProportional: false,
   upsetMaxIntersections: 10,
@@ -1020,9 +1039,25 @@ function buildRocExample() {
     const score = truth
       ? model.positiveBase + model.positiveSpan * (1 - rank) + wave
       : model.negativeBase + model.negativeSpan * (1 - rank) - wave;
-    return `${truth}\t${Math.max(0.01, Math.min(0.99, score)).toFixed(4)}\t${model.name}`;
+    return `S${String(index + 1).padStart(2, "0")}\t${truth}\t${Math.max(0.01, Math.min(0.99, score)).toFixed(4)}\t${model.name}`;
   }));
-  return `truth\tscore\tmodel\n${rows.join("\n")}`;
+  return `sample\ttruth\tscore\tmodel\n${rows.join("\n")}`;
+}
+
+function buildTimeDependentRocExample() {
+  const curves = [
+    { model: "Clinical model", horizon: 12, auc: 0.742, lower: 0.681, upper: 0.803, lift: 0.66 },
+    { model: "Clinical model", horizon: 36, auc: 0.781, lower: 0.724, upper: 0.838, lift: 0.74 },
+    { model: "Integrated model", horizon: 12, auc: 0.816, lower: 0.764, upper: 0.868, lift: 0.83 },
+    { model: "Integrated model", horizon: 36, auc: 0.847, lower: 0.799, upper: 0.895, lift: 0.91 },
+  ];
+  const rows = curves.flatMap((curve) => Array.from({ length: 11 }, (_, index) => {
+    const fpr = index / 10;
+    const tpr = Math.min(1, Math.pow(fpr, 1 / (1 + curve.lift * 3.2)));
+    const halfWidth = index === 0 || index === 10 ? 0 : 0.035 + Math.sin(Math.PI * fpr) * 0.025;
+    return [fpr, tpr, Math.max(0, tpr - halfWidth), Math.min(1, tpr + halfWidth), curve.horizon, curve.model, curve.auc, curve.lower, curve.upper].map((value) => typeof value === "number" ? value.toFixed(3) : value).join("\t");
+  }));
+  return `fpr\ttpr\ttpr_lower\ttpr_upper\thorizon\tgroup\tauc\tauc_lower\tauc_upper\n${rows.join("\n")}`;
 }
 
 const demoChromosomeLengths = [249_250_621, 243_199_373, 198_022_430, 191_154_276, 180_915_260, 171_115_067, 159_138_663, 146_364_022, 141_213_431, 135_534_747, 135_006_516, 133_851_895];
@@ -1284,6 +1319,62 @@ Male vs female\t1.11\t0.84\t1.47\tClinical
 Stage III-IV\t2.08\t1.45\t2.98\tClinical
 High signature\t1.73\t1.20\t2.49\tMolecular`,
   roc: buildRocExample(),
+  rocTimeDependent: buildTimeDependentRocExample(),
+  funnel: `study\teffect\tse
+Study A\t0.42\t0.11
+Study B\t0.31\t0.16
+Study C\t0.58\t0.13
+Study D\t0.27\t0.22
+Study E\t0.49\t0.09
+Study F\t0.18\t0.25
+Study G\t0.55\t0.18`,
+  nomogram: `predictor\tlevel\tpoints
+Age\t40\t8
+Age\t60\t24
+Age\t80\t42
+Stage\tI\t0
+Stage\tII\t28
+Stage\tIII\t61
+Biomarker\tLow\t0
+Biomarker\tHigh\t54`,
+  lasso: `lambda\tcoefficient\tfeature
+1\t0\tGene A
+0.3\t0.12\tGene A
+0.1\t0.31\tGene A
+0.03\t0.48\tGene A
+1\t0\tGene B
+0.3\t-0.08\tGene B
+0.1\t-0.21\tGene B
+0.03\t-0.38\tGene B
+1\t0\tClinical score
+0.3\t0.18\tClinical score
+0.1\t0.26\tClinical score
+0.03\t0.29\tClinical score`,
+  kmCutoff: `time\tevent\tscore\tcutoff
+4\t1\t0.82\t0.50
+7\t0\t0.31\t0.50
+9\t1\t0.74\t0.50
+12\t1\t0.65\t0.50
+14\t0\t0.42\t0.50
+18\t1\t0.58\t0.50
+20\t0\t0.22\t0.50
+24\t0\t0.37\t0.50
+28\t1\t0.91\t0.50
+32\t0\t0.48\t0.50
+36\t0\t0.18\t0.50
+40\t1\t0.69\t0.50`,
+  riskScore: `sample\tscore\toutcome
+S01\t0.12\t0
+S02\t0.19\t0
+S03\t0.25\t1
+S04\t0.31\t0
+S05\t0.39\t0
+S06\t0.47\t1
+S07\t0.54\t0
+S08\t0.62\t1
+S09\t0.71\t1
+S10\t0.83\t1
+S11\t0.91\t1`,
   sets: `item\tset
 TP53\tRNA-seq
 EGFR\tRNA-seq
@@ -1910,15 +2001,54 @@ const plotDefinitionSeeds: PlotDefinition[] = [
     id: "roc",
     name: "ROC",
     family: "Model evaluation",
-    summary: "ROC curves and trapezoidal AUC calculated directly from binary outcomes and continuous scores.",
-    inputHint: "Truth must be 0/1. Use held-out or externally validated prediction scores to avoid optimistic performance.",
+    summary: "Raw multi-model ROC or supplied time-dependent ROC curves with explicit uncertainty and evaluation horizons.",
+    inputHint: "Raw mode calculates ROC/AUC from 0/1 outcomes and held-out scores. Time-dependent mode displays upstream estimates and pointwise 95% confidence limits without recomputing censoring-aware statistics.",
     roles: [
       { key: "truth", label: "True class (0 / 1)", kind: "number", required: true },
       { key: "score", label: "Prediction score", kind: "number", required: true },
       { key: "group", label: "Model", kind: "category", required: false },
+      { key: "fpr", label: "False-positive rate", kind: "number", required: true },
+      { key: "tpr", label: "True-positive rate", kind: "number", required: true },
+      { key: "tprLower", label: "TPR lower 95% CI", kind: "number", required: true },
+      { key: "tprUpper", label: "TPR upper 95% CI", kind: "number", required: true },
+      { key: "horizon", label: "Evaluation horizon", kind: "number", required: true },
+      { key: "auc", label: "AUC", kind: "number", required: true },
+      { key: "aucLower", label: "AUC lower 95% CI", kind: "number", required: true },
+      { key: "aucUpper", label: "AUC upper 95% CI", kind: "number", required: true },
     ],
-    defaultMapping: { truth: "truth", score: "score", group: "model" },
+    defaultMapping: { truth: "truth", score: "score", group: "model", fpr: "", tpr: "", tprLower: "", tprUpper: "", horizon: "", auc: "", aucLower: "", aucUpper: "" },
     sampleData: samples.roc,
+    examples: [
+      { label: "Example 1 · Raw predictions", description: "Two models evaluated on binary outcomes; ROC and trapezoidal AUC are calculated in-browser.", data: samples.roc, mapping: { truth: "truth", score: "score", group: "model", fpr: "", tpr: "", tprLower: "", tprUpper: "", horizon: "", auc: "", aucLower: "", aucUpper: "" } },
+      { label: "Example 2 · Time-dependent + CI", description: "Censoring-aware time-dependent ROC coordinates, pointwise TPR intervals, horizons, and AUC intervals supplied by an upstream survival model.", data: samples.rocTimeDependent, mapping: { truth: "", score: "", group: "group", fpr: "fpr", tpr: "tpr", tprLower: "tpr_lower", tprUpper: "tpr_upper", horizon: "horizon", auc: "auc", aucLower: "auc_lower", aucUpper: "auc_upper" }, settings: { rocInputMode: "precomputed-time" } },
+    ],
+  },
+  {
+    id: "funnel", name: "Funnel", family: "Evidence synthesis", summary: "Study effects against precision with inverse-variance center and pseudo 95% funnel limits.", inputHint: "One row per independent study estimate. SE must be positive and on the same effect scale; asymmetry is not by itself proof of publication bias.",
+    roles: [{ key: "label", label: "Study", kind: "label", required: true }, { key: "estimate", label: "Effect estimate", kind: "number", required: true }, { key: "error", label: "Standard error", kind: "number", required: true }], defaultMapping: { label: "study", estimate: "effect", error: "se" }, sampleData: samples.funnel,
+  },
+  ...(["precision-recall", "calibration", "decision-curve"] as const).map((id) => ({
+    id, name: id === "precision-recall" ? "Precision–recall" : id === "calibration" ? "Calibration" : "Decision curve", family: "Model evaluation",
+    summary: id === "precision-recall" ? "Precision–recall curves and average precision from binary outcomes and held-out scores." : id === "calibration" ? "Grouped observed-versus-predicted calibration with Wilson 95% intervals and identity reference." : "Net benefit across threshold probabilities with treat-all and treat-none references.",
+    inputHint: id === "precision-recall" ? "One row per subject per model. Outcome must be 0/1; any continuous held-out ranking score is accepted. Average precision is prevalence-dependent." : "One row per subject per model. Outcome must be 0/1; prediction must be a held-out probability in [0,1]. Repeated subjects across model names are allowed.",
+    roles: [{ key: "subject", label: "Subject ID", kind: "label" as const, required: false }, { key: "truth", label: "Observed outcome (0 / 1)", kind: "number" as const, required: true }, { key: "score", label: id === "precision-recall" ? "Prediction / ranking score" : "Predicted probability", kind: "number" as const, required: true }, { key: "group", label: "Model", kind: "category" as const, required: false }],
+    defaultMapping: { subject: "sample", truth: "truth", score: "score", group: "model" }, sampleData: samples.roc,
+  })),
+  {
+    id: "nomogram", name: "Nomogram", family: "Clinical prediction", summary: "Aligned predictor-level point assignments supplied by a documented fitted model.", inputHint: "Provide predictor, displayed level, and already-derived points. This renderer does not fit a model or infer individual risk.",
+    roles: [{ key: "group", label: "Predictor", kind: "category", required: true }, { key: "label", label: "Level", kind: "label", required: true }, { key: "value", label: "Assigned points", kind: "number", required: true }], defaultMapping: { group: "predictor", label: "level", value: "points" }, sampleData: samples.nomogram,
+  },
+  {
+    id: "lasso-path", name: "LASSO path", family: "Model development", summary: "Coefficient trajectories across positive regularization parameters from an upstream penalized model.", inputHint: "Provide one row per feature and lambda. Paths are descriptive; model selection and cross-validation must be performed upstream without test-set leakage.",
+    roles: [{ key: "x", label: "Lambda", kind: "number", required: true }, { key: "y", label: "Coefficient", kind: "number", required: true }, { key: "group", label: "Feature", kind: "category", required: true }], defaultMapping: { x: "lambda", y: "coefficient", group: "feature" }, sampleData: samples.lasso,
+  },
+  {
+    id: "km-cutoff", name: "Cutoff KM", family: "Survival", summary: "Kaplan–Meier curves stratified by a single supplied risk-score cutoff.", inputHint: "Provide subject-level follow-up, event, risk score, and one constant cutoff derived upstream. Optimizing and evaluating the cutoff in the same cohort is exploratory and optimistic.",
+    roles: [{ key: "time", label: "Follow-up time", kind: "number", required: true }, { key: "event", label: "Event (0 / 1)", kind: "number", required: true }, { key: "score", label: "Risk score", kind: "number", required: true }, { key: "cutoff", label: "Supplied cutoff", kind: "number", required: true }], defaultMapping: { time: "time", event: "event", score: "score", cutoff: "cutoff" }, sampleData: samples.kmCutoff,
+  },
+  {
+    id: "risk-score", name: "Risk-score panel", family: "Model evaluation", summary: "Subjects ranked by supplied risk score with an aligned binary-outcome strip.", inputHint: "One row per subject with a score and observed 0/1 outcome. This descriptive panel does not estimate discrimination, calibration, or clinical utility.",
+    roles: [{ key: "label", label: "Subject", kind: "label", required: true }, { key: "score", label: "Risk score", kind: "number", required: true }, { key: "truth", label: "Observed outcome (0 / 1)", kind: "number", required: true }], defaultMapping: { label: "sample", score: "score", truth: "outcome" }, sampleData: samples.riskScore,
   },
   ...(["venn", "upset"] as const).map((id) => ({
     id,
@@ -2283,6 +2413,14 @@ export const plotReferences = {
   kaplanMeier: { citation: "Kaplan & Meier, 1958. Nonparametric Estimation from Incomplete Observations. JASA.", href: "https://doi.org/10.1080/01621459.1958.10501452" },
   forest: { citation: "Lewis & Clarke, 2001. Forest plots: trying to see the wood and the trees. BMJ.", href: "https://doi.org/10.1136/bmj.322.7300.1479" },
   roc: { citation: "Hanley & McNeil, 1982. The meaning and use of the area under a ROC curve. Radiology.", href: "https://doi.org/10.1148/radiology.143.1.7063747" },
+  funnel: { citation: "Egger et al., 1997. Bias in meta-analysis detected by a simple, graphical test. BMJ.", href: "https://doi.org/10.1136/bmj.315.7109.629" },
+  precisionRecall: { citation: "Saito & Rehmsmeier, 2015. The Precision-Recall Plot Is More Informative than the ROC Plot When Evaluating Binary Classifiers on Imbalanced Datasets. PLoS ONE.", href: "https://doi.org/10.1371/journal.pone.0118432" },
+  calibration: { citation: "Van Calster et al., 2019. Calibration: the Achilles heel of predictive analytics. BMC Medicine.", href: "https://doi.org/10.1186/s12916-019-1466-7" },
+  decisionCurve: { citation: "Vickers & Elkin, 2006. Decision curve analysis: a novel method for evaluating prediction models. Medical Decision Making.", href: "https://doi.org/10.1177/0272989X06295361" },
+  nomogram: { citation: "Iasonos et al., 2008. How to build and interpret a nomogram for cancer prognosis. Journal of Clinical Oncology.", href: "https://doi.org/10.1200/JCO.2007.12.9791" },
+  lasso: { citation: "Tibshirani, 1996. Regression Shrinkage and Selection via the Lasso. Journal of the Royal Statistical Society B.", href: "https://doi.org/10.1111/j.2517-6161.1996.tb02080.x" },
+  cutoff: { citation: "Altman et al., 1994. Dangers of using optimal cutpoints in the evaluation of prognostic factors. Journal of the National Cancer Institute.", href: "https://doi.org/10.1093/jnci/86.11.829" },
+  tripod: { citation: "Collins et al., 2015. Transparent Reporting of a multivariable prediction model for Individual Prognosis Or Diagnosis (TRIPOD). Annals of Internal Medicine.", href: "https://doi.org/10.7326/M14-0697" },
   venn: { citation: "Venn, 1880. On the Diagrammatic and Mechanical Representation of Propositions and Reasonings. Philosophical Magazine.", href: "https://doi.org/10.1080/14786448008626877" },
   upset: { citation: "Lex et al., 2014. UpSet: Visualization of Intersecting Sets. IEEE TVCG.", href: "https://doi.org/10.1109/TVCG.2014.2346248" },
   sankeyHistory: { citation: "Schmidt, 2008. The Sankey Diagram in Energy and Material Flow Management: Part I. J Ind Ecol.", href: "https://doi.org/10.1111/j.1530-9290.2008.00004.x" },
@@ -2520,12 +2658,20 @@ const plotGuidanceSeeds: Record<PlotType, PlotGuidance> = {
     references: [plotReferences.forest],
   },
   roc: {
-    definition: "遍历二分类预测阈值，以假阳性率为 X、真阳性率为 Y，展示敏感度与特异度之间的权衡。",
-    suitableData: "二分类真实标签与连续预测分数，最好来自验证集或外部队列。",
-    answers: "模型区分两类对象的能力和不同阈值下敏感度/特异度权衡如何；不能说明校准。",
+    definition: "普通模式遍历二分类预测阈值；时间依赖模式显示上游删失感知方法提供的 FPR、TPR、逐点区间、评价时点和 AUC 区间。",
+    suitableData: "验证集或外部队列的二分类真实标签与连续预测分数，或由明确生存方法计算的时间依赖 ROC 坐标与不确定性。",
+    answers: "模型区分两类对象的能力和不同阈值下敏感度/特异度权衡如何；时间依赖模式还比较指定时点，但两种模式都不能说明校准或临床效用。",
     origin: "ROC 的思想源自信号检测问题，随后进入诊断检验和预测模型评价；AUC 可解释为随机阳性样本得分高于随机阴性样本的概率。",
     references: [plotReferences.roc],
   },
+  funnel: { definition: "把独立研究的效应量放在横轴、精度 1/SE 放在纵轴，并叠加逆方差中心与伪 95% 漏斗边界。", suitableData: "同一效应尺度上的研究级估计与正标准误。", answers: "研究结果是否围绕汇总效应近似对称；不对称也可能来自异质性、小样本效应或方法差异，不能单独证明发表偏倚。", origin: "漏斗图源于荟萃分析中用于观察小样本效应和结果不对称性的图形诊断方法。", references: [plotReferences.funnel] },
+  "precision-recall": { definition: "遍历分类阈值，以召回率为横轴、阳性预测值为纵轴，并计算 average precision。", suitableData: "二分类结局与独立验证或交叉验证得到的连续分数。", answers: "在类别不平衡时，模型找回阳性与保持阳性预测值之间的权衡。", references: [plotReferences.precisionRecall, plotReferences.tripod] },
+  calibration: { definition: "按预测概率分箱，比较每箱平均预测概率与实际事件比例，并显示 Wilson 95% 区间和理想对角线。", suitableData: "0/1 观察结局和真正概率尺度的预测值。", answers: "预测概率是否系统性过高或过低；分箱图不能替代校准截距、斜率和外部验证。", references: [plotReferences.calibration, plotReferences.tripod] },
+  "decision-curve": { definition: "在一系列阈值概率下计算模型净获益，并与 treat-all 和 treat-none 策略比较。", suitableData: "0/1 结局与验证集预测概率；阈值范围应有临床意义。", answers: "在给定错判权衡下使用模型是否比全做或全不做更有净获益；不是治疗建议。", references: [plotReferences.decisionCurve, plotReferences.tripod] },
+  nomogram: { definition: "把已拟合模型中不同预测变量水平转换成对齐的积分标尺。", suitableData: "上游模型已经给出的 predictor-level points。", answers: "各变量水平如何贡献模型积分；本图不重新拟合模型，也不能证明临床有效性。", references: [plotReferences.nomogram, plotReferences.tripod] },
+  "lasso-path": { definition: "展示 L1 正则化参数变化时各特征系数从零进入并收缩的轨迹。", suitableData: "上游 penalized regression 输出的 lambda、feature、coefficient 长表。", answers: "不同正则化强度下模型稀疏性和系数稳定性如何；最终 lambda 必须在训练流程内选择。", references: [plotReferences.lasso, plotReferences.tripod] },
+  "km-cutoff": { definition: "使用一个明确提供的风险分数截点把受试者分组，再计算 Kaplan–Meier 曲线。", suitableData: "随访时间、删失事件、连续风险分数和同一常数截点。", answers: "该预先指定或上游优化截点下两组生存经验分布如何；同队列寻优再评价会夸大差异。", references: [plotReferences.kaplanMeier, plotReferences.cutoff] },
+  "risk-score": { definition: "按风险分数排序受试者，并对齐显示二分类结局条带。", suitableData: "每位受试者一个风险分数和0/1观察结局。", answers: "分数排序与结局分布的描述性关系；不能替代 ROC、校准、DCA 或外部验证。", references: [plotReferences.tripod] },
   venn: {
     definition: "用经典圆形（2–3 集合）或径向精确交集索引（4–7 集合）表示观察到的集合组合；径向模式不是闭合曲线 Venn 图。",
     suitableData: "2–7 个集合的 item–set 成员长表，或带 set、chromosome、start、end 的 genomic peak 区间。",
@@ -2740,6 +2886,7 @@ const plotGuidanceSeeds: Record<PlotType, PlotGuidance> = {
 const advancedRendererIds = new Set<PlotType>([
   "line", "scatter", "correlation", "pca", "pcoa", "umap", "tsne", "nmds", "box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "ma", "quadrant", "errorbar", "area", "lollipop",
   "heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment-bar", "gsea", "km", "survival-forest", "roc", "venn",
+  "funnel", "precision-recall", "calibration", "decision-curve", "nomogram", "lasso-path", "km-cutoff", "risk-score",
   "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos",
   "network", "ppi", "cerna", "mirna-target", "cnet", "enrichment-map", "tree", "dendrogram",
   "manhattan", "qq", "chromosome-ideogram", "snp-density", "genome-tracks", "waterfall", "oncoplot", "motif-logo",
@@ -2750,7 +2897,7 @@ const commonSettingKeys: Array<keyof VisualizationSettings> = [
   "legendSize", "axisLineWidth", "gridLineWidth", "dataLineWidth", "pointSize", "opacity", "grid",
   "categoricalColors",
 ];
-const hiddenLegendIds = new Set<PlotType>(["box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "heatmap", "clustered-heatmap", "correlation-heatmap", "venn", "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos", "manhattan", "qq", "chromosome-ideogram", "snp-density", "genome-tracks", "waterfall", "oncoplot", "motif-logo", "treemap"]);
+const hiddenLegendIds = new Set<PlotType>(["box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "heatmap", "clustered-heatmap", "correlation-heatmap", "venn", "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos", "manhattan", "qq", "chromosome-ideogram", "snp-density", "genome-tracks", "waterfall", "oncoplot", "motif-logo", "treemap", "funnel", "precision-recall", "calibration", "decision-curve", "nomogram", "lasso-path", "km-cutoff", "risk-score"]);
 const specializedSettingKeys: Partial<Record<PlotType, Array<keyof VisualizationSettings>>> = {
   bar: ["swapAxes", "barErrorType", "barVariant", "barInputMode", "barOverlayType", "secondaryAxisLabel", "showSignificance", "significanceThreshold", "axisBreakStart", "axisBreakEnd", "barGap", "barBorderWidth", "barBorderColor", "errorBarLineWidth", "errorBarCapSize"],
   line: ["swapAxes", "showPoints", "lineErrorType", "lineUncertaintyStyle", "lineBandOpacity", "errorBarLineWidth", "errorBarCapSize"],
@@ -2776,6 +2923,9 @@ const specializedSettingKeys: Partial<Record<PlotType, Array<keyof Visualization
   "correlation-heatmap": ["correlationMethod", "heatmapDisplay", "heatmapTriangle", "clusterRows", "clusterColumns", "heatmapDistance", "heatmapLinkage", "heatmapShowDendrograms", "heatmapRowClusters", "heatmapColumnClusters", "heatmapShowValues", "heatmapShowSidePlot", "heatmapSidePlotStatistic", "heatmapLabelDensity", "heatmapRowAnnotationData", "heatmapColumnAnnotationData", "divergingLow", "divergingMid", "divergingHigh"],
   enrichment: ["continuousLow", "continuousHigh"], "enrichment-bar": ["continuousLow", "continuousHigh"],
   km: ["showRiskTable"], "survival-forest": ["forestReferenceValue"],
+  roc: ["rocInputMode"],
+  calibration: ["calibrationBinCount"],
+  "decision-curve": ["decisionThresholdMinimum", "decisionThresholdMaximum", "decisionThresholdStep"],
   pie: ["compositionLabelMode"], donut: ["compositionLabelMode", "donutHole"], waffle: ["compositionLabelMode", "waffleCells"],
   rose: ["compositionLabelMode", "radialMaximum"], treemap: ["compositionLabelMode", "hierarchyGap"], sunburst: ["compositionLabelMode", "hierarchyGap"],
   radar: ["radarFillOpacity", "radialMaximum"], "polar-profile": ["radarFillOpacity", "radialMaximum"],
@@ -2806,6 +2956,14 @@ const specializedSettingKeys: Partial<Record<PlotType, Array<keyof Visualization
 };
 
 const newAxislessSettingKeys: Partial<Record<PlotType, ReadonlySet<keyof VisualizationSettings>>> = {
+  funnel: new Set(["title", "fontFamily", "xLabel", "yLabel", "width", "height", "titleSize", "axisLabelSize", "tickSize", "axisLineWidth", "gridLineWidth", "dataLineWidth", "pointSize", "grid", "categoricalColors"]),
+  "precision-recall": new Set(["title", "fontFamily", "xLabel", "yLabel", "width", "height", "titleSize", "axisLabelSize", "tickSize", "legendSize", "axisLineWidth", "gridLineWidth", "dataLineWidth", "grid", "categoricalColors"]),
+  calibration: new Set(["title", "fontFamily", "xLabel", "yLabel", "width", "height", "titleSize", "axisLabelSize", "tickSize", "legendSize", "axisLineWidth", "gridLineWidth", "dataLineWidth", "pointSize", "grid", "categoricalColors", "calibrationBinCount"]),
+  "decision-curve": new Set(["title", "fontFamily", "xLabel", "yLabel", "width", "height", "titleSize", "axisLabelSize", "tickSize", "legendSize", "axisLineWidth", "gridLineWidth", "dataLineWidth", "grid", "categoricalColors", "decisionThresholdMinimum", "decisionThresholdMaximum", "decisionThresholdStep"]),
+  nomogram: new Set(["title", "fontFamily", "xLabel", "width", "height", "titleSize", "axisLabelSize", "tickSize", "pointSize", "categoricalColors"]),
+  "lasso-path": new Set(["title", "fontFamily", "xLabel", "yLabel", "width", "height", "titleSize", "axisLabelSize", "tickSize", "legendSize", "axisLineWidth", "gridLineWidth", "dataLineWidth", "grid", "categoricalColors"]),
+  "km-cutoff": new Set(["title", "fontFamily", "xLabel", "yLabel", "width", "height", "titleSize", "axisLabelSize", "tickSize", "legendSize", "axisLineWidth", "gridLineWidth", "dataLineWidth", "grid", "categoricalColors"]),
+  "risk-score": new Set(["title", "fontFamily", "xLabel", "yLabel", "width", "height", "titleSize", "axisLabelSize", "tickSize", "legendSize", "axisLineWidth", "dataLineWidth", "pointSize", "categoricalColors"]),
   venn: new Set(["title", "fontFamily", "width", "height", "titleSize", "axisLabelSize", "tickSize", "dataLineWidth", "opacity", "categoricalColors", "setInputMode", "vennLayout", "vennProportional"]),
   upset: new Set(["title", "fontFamily", "width", "height", "titleSize", "axisLabelSize", "tickSize", "axisLineWidth", "opacity", "categoricalColors", "setInputMode", "upsetMaxIntersections"]),
   sankey: new Set(["title", "fontFamily", "width", "height", "titleSize", "tickSize", "opacity", "categoricalColors", "showLabels"]),
@@ -2864,6 +3022,7 @@ function numericAxesFor(type: PlotType): Array<"x" | "y"> {
 }
 
 export function activeNumericAxes(type: PlotType, settings: Pick<VisualizationSettings, "swapAxes" | "barVariant" | "distributionOrientation" | "associationVariant" | "ordinationView">): Array<"x" | "y"> {
+  if (["funnel", "precision-recall", "calibration", "decision-curve", "nomogram", "lasso-path", "km-cutoff", "risk-score"].includes(type)) return [];
   if (type === "bar") {
     if (settings.barVariant === "polar") return [];
     return settings.swapAxes || ["horizontal", "bullet", "pyramid"].includes(settings.barVariant) ? ["x"] : ["y"];
@@ -2882,6 +3041,11 @@ export function isPlotRoleActive(type: PlotType, roleKey: string, settings: Visu
   if (type === "venn" || type === "upset") {
     if (roleKey === "item") return settings.setInputMode !== "peak-overlap";
     if (["chromosome", "start", "end"].includes(roleKey)) return settings.setInputMode !== "membership";
+  }
+  if (type === "roc") {
+    const precomputedRoles = ["fpr", "tpr", "tprLower", "tprUpper", "horizon", "auc", "aucLower", "aucUpper"];
+    if (["truth", "score"].includes(roleKey)) return settings.rocInputMode === "raw";
+    if (precomputedRoles.includes(roleKey)) return settings.rocInputMode === "precomputed-time";
   }
   if (type !== "bar") return true;
   if (roleKey === "secondary") return ["dual-axis", "overlay"].includes(settings.barVariant);
@@ -3168,19 +3332,19 @@ export function parseRatioValue(value: string | undefined) {
 
 const mappingAliases: Record<string, string[]> = {
   category: ["category", "condition", "sample", "name", "term"],
-  value: ["value", "weight", "mean", "expression", "score", "abundance", "count", "variantcount", "density"],
+  value: ["value", "weight", "mean", "expression", "score", "points", "abundance", "count", "variantcount", "density"],
   secondary: ["secondary", "secondaryvalue", "comparison", "overlay", "value2"],
   target: ["target", "reference", "goal", "benchmark", "to", "receiver"],
   facet: ["facet", "panel", "stratum", "cohort"],
-  subject: ["subject", "subjectid", "pair", "pairid", "participant", "sampleid"],
-  group: ["group", "class", "condition", "cluster", "ontology"],
+  subject: ["subject", "subjectid", "pair", "pairid", "participant", "sample", "sampleid"],
+  group: ["group", "class", "condition", "cluster", "ontology", "model", "predictor", "feature"],
   series: ["series", "group", "condition", "class"],
-  x: ["x", "time", "dose", "pc1", "dim1", "dimension1", "umap1", "tsne1", "nmds1"],
-  y: ["y", "response", "pc2", "dim2", "dimension2", "umap2", "tsne2", "nmds2"],
+  x: ["x", "time", "dose", "lambda", "pc1", "dim1", "dimension1", "umap1", "tsne1", "nmds1"],
+  y: ["y", "response", "coefficient", "pc2", "dim2", "dimension2", "umap2", "tsne2", "nmds2"],
   z: ["z", "pc3", "dim3", "dimension3", "umap3", "tsne3", "nmds3"],
   shape: ["shape", "batch", "cohort", "site", "sex"],
   error: ["error", "sd", "sem", "se", "stderr", "standarddeviation", "standarderror"],
-  label: ["label", "gene", "feature", "id", "name"],
+  label: ["label", "gene", "feature", "id", "name", "study", "sample", "level"],
   effect: ["log2fc", "logfc", "effect", "estimate"],
   pValue: ["padj", "fdr", "adjustedpvalue", "pvalue", "p"],
   term: ["term", "pathway", "description", "name"],
@@ -3191,11 +3355,12 @@ const mappingAliases: Record<string, string[]> = {
   hit: ["hit", "member", "membership", "ingeneset"],
   time: ["time", "followuptime", "survivaltime", "os", "pfs"],
   event: ["event", "status", "death", "outcome"],
-  estimate: ["estimate", "hr", "hazardratio", "or", "oddsratio"],
+  estimate: ["estimate", "effect", "hr", "hazardratio", "or", "oddsratio"],
   lower: ["lower", "lowerci", "cilower", "lcl"],
   upper: ["upper", "upperci", "ciupper", "ucl"],
   truth: ["truth", "class", "outcome", "label", "event"],
   score: ["score", "prediction", "probability", "risk", "runninges", "enrichmentscore", "es"],
+  cutoff: ["cutoff", "threshold"],
   item: ["item", "gene", "feature", "id"],
   set: ["set", "geneset", "list", "collection"],
   source: ["source", "from", "sender"],
@@ -4003,11 +4168,164 @@ export function validatePlotDataset(
     if (invalidTimes > 0) errors.push(`Follow-up time contains ${invalidTimes} negative value${invalidTimes === 1 ? "" : "s"}.`);
   }
 
-  if (definition.id === "roc" && mapping.truth) {
+  if (definition.id === "roc" && (settings?.rocInputMode ?? "raw") === "raw" && mapping.truth) {
     const invalidTruth = dataset.rows.filter((row) => ![0, 1].includes(parseNumericValue(row[mapping.truth]) ?? Number.NaN)).length;
     if (invalidTruth > 0) errors.push(`True class contains ${invalidTruth} value${invalidTruth === 1 ? "" : "s"} other than 0 or 1.`);
-    const classes = new Set(dataset.rows.map((row) => parseNumericValue(row[mapping.truth])));
-    if (invalidTruth === 0 && classes.size < 2) errors.push("ROC calculation requires both outcome classes (0 and 1).");
+    const groups = [...new Set(dataset.rows.map((row) => mapping.group ? row[mapping.group] || "Model" : "Model"))];
+    if (invalidTruth === 0) groups.forEach((group) => {
+      const classes = new Set(dataset.rows.filter((row) => (mapping.group ? row[mapping.group] || "Model" : "Model") === group).map((row) => parseNumericValue(row[mapping.truth])));
+      if (classes.size < 2) errors.push(groups.length === 1 ? "ROC calculation requires both outcome classes (0 and 1)." : `ROC model “${group}” requires both outcome classes (0 and 1).`);
+    });
+    warnings.push("ROC/AUC describe discrimination in the supplied predictions. They are not evidence of calibration, clinical utility, or external validation.");
+  }
+  if (definition.id === "roc" && settings) {
+    if ((settings.xMin !== null && settings.xMin > 0) || (settings.xMax !== null && settings.xMax < 1) || (settings.yMin !== null && settings.yMin > 0) || (settings.yMax !== null && settings.yMax < 1)) errors.push("ROC manual axis limits must contain the full [0, 1] false-positive and true-positive range so curve endpoints and confidence bands are not clipped.");
+  }
+
+  if (definition.id === "roc" && settings?.rocInputMode === "precomputed-time" && mapping.fpr && mapping.tpr) {
+    const probabilityRoles = ["fpr", "tpr", "tprLower", "tprUpper", "auc", "aucLower", "aucUpper"] as const;
+    probabilityRoles.forEach((role) => {
+      if (!mapping[role]) return;
+      const invalid = dataset.rows.filter((row) => { const value = parseNumericValue(row[mapping[role]]); return value === null || value < 0 || value > 1; }).length;
+      if (invalid > 0) errors.push(`${role} contains ${invalid} value${invalid === 1 ? "" : "s"} outside [0, 1].`);
+    });
+    const invalidHorizon = mapping.horizon ? dataset.rows.filter((row) => (parseNumericValue(row[mapping.horizon]) ?? 0) <= 0).length : 0;
+    if (invalidHorizon > 0) errors.push(`Evaluation horizon contains ${invalidHorizon} non-positive or missing value${invalidHorizon === 1 ? "" : "s"}.`);
+    const curveKeys = new Set(dataset.rows.map((row) => `${mapping.group ? row[mapping.group] || "Model" : "Model"}\u0000${parseNumericValue(row[mapping.horizon])}`));
+    const maximumCurves = settings.legendPosition === "bottom" ? 4 : settings.legendPosition === "right" ? Math.max(2, Math.floor((settings.height - (settings.title ? 48 : 24) - 58) / (settings.legendSize * 2 + 11))) : 12;
+    if (curveKeys.size > maximumCurves) errors.push(`The ${settings.legendPosition} time-dependent ROC layout can display ${maximumCurves} model × horizon curves at this height; reduce curves, hide the legend, or increase height.`);
+    curveKeys.forEach((key) => {
+      const [group, horizon] = key.split("\u0000");
+      const numericHorizon = Number(horizon);
+      const rows = dataset.rows.filter((row) => (mapping.group ? row[mapping.group] || "Model" : "Model") === group && parseNumericValue(row[mapping.horizon]) === numericHorizon).sort((a, b) => (parseNumericValue(a[mapping.fpr]) ?? 0) - (parseNumericValue(b[mapping.fpr]) ?? 0));
+      const monotone = rows.every((row, index) => index === 0 || (parseNumericValue(row[mapping.tpr]) ?? 0) >= (parseNumericValue(rows[index - 1][mapping.tpr]) ?? 0));
+      const startsAtOrigin = (parseNumericValue(rows[0]?.[mapping.fpr]) ?? -1) === 0 && (parseNumericValue(rows[0]?.[mapping.tpr]) ?? -1) === 0;
+      const endsAtOne = (parseNumericValue(rows.at(-1)?.[mapping.fpr]) ?? -1) === 1 && (parseNumericValue(rows.at(-1)?.[mapping.tpr]) ?? -1) === 1;
+      if (!monotone || !startsAtOrigin || !endsAtOne) errors.push(`ROC curve “${group} · ${horizon}” must be monotone and include (0,0) and (1,1).`);
+      const invalidIntervals = rows.filter((row) => {
+        const tpr = parseNumericValue(row[mapping.tpr]); const lower = parseNumericValue(row[mapping.tprLower]); const upper = parseNumericValue(row[mapping.tprUpper]);
+        const auc = parseNumericValue(row[mapping.auc]); const aucLower = parseNumericValue(row[mapping.aucLower]); const aucUpper = parseNumericValue(row[mapping.aucUpper]);
+        return tpr === null || lower === null || upper === null || lower > tpr || tpr > upper || auc === null || aucLower === null || aucUpper === null || aucLower > auc || auc > aucUpper;
+      }).length;
+      if (invalidIntervals > 0) errors.push(`ROC curve “${group} · ${horizon}” has ${invalidIntervals} unordered TPR or AUC confidence interval row${invalidIntervals === 1 ? "" : "s"}.`);
+      const aucTriples = new Set(rows.map((row) => [mapping.auc, mapping.aucLower, mapping.aucUpper].map((role) => row[role]).join("\u0000")));
+      if (aucTriples.size !== 1) errors.push(`ROC curve “${group} · ${horizon}” must repeat one consistent AUC and confidence interval across its coordinates.`);
+    });
+    warnings.push("Time-dependent ROC estimates are displayed as supplied. Document the censoring method, evaluation cohort, prediction horizon, and uncertainty procedure in the upstream analysis.");
+  }
+
+  if (["precision-recall", "calibration", "decision-curve", "risk-score"].includes(definition.id) && mapping.truth) {
+    const invalidTruth = dataset.rows.filter((row) => ![0, 1].includes(parseNumericValue(row[mapping.truth]) ?? Number.NaN)).length;
+    if (invalidTruth > 0) errors.push(`Observed outcome contains ${invalidTruth} value${invalidTruth === 1 ? "" : "s"} other than 0 or 1.`);
+    const groups = [...new Set(dataset.rows.map((row) => mapping.group ? row[mapping.group] || "Model" : "Model"))];
+    if (invalidTruth === 0) groups.forEach((group) => {
+      const classes = new Set(dataset.rows.filter((row) => (mapping.group ? row[mapping.group] || "Model" : "Model") === group).map((row) => parseNumericValue(row[mapping.truth])));
+      if (classes.size < 2) errors.push(`${definition.name} model “${group}” requires both observed outcome classes (0 and 1).`);
+    });
+    if (["calibration", "decision-curve"].includes(definition.id) && mapping.score) {
+      const outside = dataset.rows.filter((row) => { const value = parseNumericValue(row[mapping.score]); return value === null || value < 0 || value > 1; }).length;
+      if (outside > 0) errors.push(`Predicted probability contains ${outside} value${outside === 1 ? "" : "s"} outside [0, 1].`);
+    }
+  }
+  if (settings && ["precision-recall", "calibration", "decision-curve"].includes(definition.id)) {
+    const groups = new Set(dataset.rows.map((row) => mapping.group ? row[mapping.group] || "Model" : "Model"));
+    const plotHeight = Math.max(90, settings.height - (settings.title ? 48 : 24) - 58);
+    const maximumModels = Math.max(2, Math.min(12, Math.floor(plotHeight * 0.35 / (settings.legendSize + 4))));
+    if (groups.size > maximumModels) errors.push(`${definition.name} can display ${maximumModels} model labels in this compact ${settings.height}px-high figure; reduce models or increase height.`);
+    if (definition.id === "calibration") groups.forEach((group) => {
+      const count = dataset.rows.filter((row) => (mapping.group ? row[mapping.group] || "Model" : "Model") === group).length;
+      if (count < 20) warnings.push(`Calibration model “${group}” has only ${count} observations; grouped observed proportions and Wilson intervals will be unstable.`);
+    });
+  }
+  if (definition.id === "decision-curve" && mapping.group) {
+    const groups = [...new Set(dataset.rows.map((row) => row[mapping.group] || "Model"))];
+    if (groups.length > 1) {
+      if (!mapping.subject) errors.push("Multi-model decision curves require a Subject ID column so every model can be verified on the same cohort and outcomes.");
+      else {
+        const expectedGroups = [...groups].sort(); const subjectRows = new Map<string, typeof dataset.rows>();
+        const blankSubjects = dataset.rows.filter((row) => !row[mapping.subject]?.trim()).length;
+        if (blankSubjects > 0) errors.push(`Decision-curve Subject ID contains ${blankSubjects} blank value${blankSubjects === 1 ? "" : "s"}; every prediction must identify its subject.`);
+        dataset.rows.forEach((row) => { const subject = row[mapping.subject]; const rows = subjectRows.get(subject) ?? []; rows.push(row); subjectRows.set(subject, rows); });
+        subjectRows.forEach((rows, subject) => {
+          const observedGroups = [...new Set(rows.map((row) => row[mapping.group] || "Model"))].sort(); const truths = new Set(rows.map((row) => parseNumericValue(row[mapping.truth])));
+          if (observedGroups.length !== expectedGroups.length || observedGroups.some((group, index) => group !== expectedGroups[index]) || rows.length !== expectedGroups.length) errors.push(`Subject “${subject || "(blank)"}” must have exactly one prediction from every decision-curve model.`);
+          if (truths.size !== 1) errors.push(`Subject “${subject}” has inconsistent observed outcomes across decision-curve models.`);
+        });
+      }
+    }
+  }
+
+  if (definition.id === "funnel" && mapping.error) {
+    const invalid = dataset.rows.filter((row) => (parseNumericValue(row[mapping.error]) ?? 0) <= 0).length;
+    if (invalid > 0) errors.push(`Standard error must be strictly positive in every study; invalid rows: ${invalid}.`);
+  }
+  if (definition.id === "calibration" && settings && (!Number.isInteger(settings.calibrationBinCount) || settings.calibrationBinCount < 3 || settings.calibrationBinCount > 15)) errors.push("Calibration equal-frequency bins must be an integer from 3 to 15.");
+  if (definition.id === "decision-curve" && settings) {
+    const { decisionThresholdMinimum: minimum, decisionThresholdMaximum: maximum, decisionThresholdStep: step } = settings;
+    if (![minimum, maximum, step].every(Number.isFinite) || minimum <= 0 || minimum >= maximum || maximum >= 1) errors.push("Decision-curve thresholds must satisfy 0 < minimum < maximum < 1.");
+    if (!Number.isFinite(step) || step < 0.005 || step > 0.05) errors.push("Decision-curve grid resolution must be between 0.005 and 0.05.");
+    const gridCount = Number.isFinite(step) && step > 0 ? Math.ceil((maximum - minimum) / step) + 1 : Number.POSITIVE_INFINITY;
+    if (gridCount < 5 || gridCount > 200) errors.push(`Decision-curve threshold grid contains ${Number.isFinite(gridCount) ? gridCount : "an invalid number of"} points; choose 5–200 points by adjusting the interval or resolution.`);
+  }
+  if (definition.id === "lasso-path" && mapping.x) {
+    const invalid = dataset.rows.filter((row) => (parseNumericValue(row[mapping.x]) ?? 0) <= 0).length;
+    if (invalid > 0) errors.push(`LASSO lambda must be strictly positive before the log₁₀ transform; invalid rows: ${invalid}.`);
+    const features = new Set(dataset.rows.map((row) => row[mapping.group]));
+    if (features.size > 12) errors.push("The compact LASSO path view supports at most 12 identified coefficient paths; filter to interpretable features or increase upstream sparsity.");
+    if (settings) {
+      const plotHeight = Math.max(90, settings.height - (settings.title ? 48 : 24) - 58);
+      const labelFont = Math.max(8, settings.legendSize - 1); const labelStep = labelFont + 3;
+      const maximumLabels = Math.max(1, Math.floor((plotHeight - labelFont - 4) / labelStep) + 1);
+      if (features.size > maximumLabels) errors.push(`LASSO labels need more vertical space at ${settings.legendSize} pt: ${features.size} paths supplied, ${maximumLabels} fit without overlap. Increase height, reduce legend size, or filter features.`);
+    }
+    const referenceGrid = new Set<number>(); let referenceFeature = "";
+    features.forEach((feature) => {
+      const rows = dataset.rows.filter((row) => row[mapping.group] === feature); const byLambda = new Map<number, number[]>();
+      rows.forEach((row) => { const lambda = parseNumericValue(row[mapping.x]); const coefficient = parseNumericValue(row[mapping.y]); if (lambda === null || coefficient === null) return; const values = byLambda.get(lambda) ?? []; values.push(coefficient); byLambda.set(lambda, values); });
+      if (byLambda.size < 2) errors.push(`LASSO feature “${feature}” requires at least two unique lambda values to form a path.`);
+      byLambda.forEach((coefficients, lambda) => { if (coefficients.length !== 1) errors.push(`LASSO feature “${feature}” has ${coefficients.length} rows at lambda ${lambda}; each feature × lambda pair must be unique.`); });
+      const grid = new Set(byLambda.keys());
+      if (!referenceFeature) { referenceFeature = feature; grid.forEach((lambda) => referenceGrid.add(lambda)); }
+      else if (grid.size !== referenceGrid.size || [...grid].some((lambda) => !referenceGrid.has(lambda))) errors.push(`LASSO feature “${feature}” does not use the same lambda grid as “${referenceFeature}”.`);
+    });
+  }
+  if (definition.id === "nomogram" && mapping.value) {
+    const invalid = dataset.rows.filter((row) => (parseNumericValue(row[mapping.value]) ?? -1) < 0).length;
+    if (invalid > 0) errors.push(`Nomogram points must be non-negative; invalid rows: ${invalid}.`);
+    if (settings) {
+      const predictors = new Set(dataset.rows.map((row) => row[mapping.group]));
+      const plotHeight = Math.max(90, settings.height - (settings.title ? 48 : 24) - 58);
+      const maximumPredictors = Math.max(2, Math.floor(plotHeight / Math.max(settings.tickSize + 9, settings.pointSize * 1.1 + 9)));
+      if (predictors.size > maximumPredictors) errors.push(`Nomogram predictor rows need more vertical space: ${predictors.size} supplied, ${maximumPredictors} fit at the current height and text size.`);
+      const maximum = Math.max(...dataset.rows.map((row) => parseNumericValue(row[mapping.value]) ?? 0), 1); const scaleEnd = maximum * 1.03; const laneWidth = Math.max(30, Math.max(100, settings.width - 88) - 70); const labelFont = Math.max(7, settings.tickSize - 2);
+      predictors.forEach((predictor) => {
+        const levels = dataset.rows.filter((row) => row[mapping.group] === predictor).map((row) => { const label = compactLegendLabel(row[mapping.label], labelFont, 42, 10); const width = estimateLegendTextWidth(label, labelFont); const pointX = (parseNumericValue(row[mapping.value]) ?? 0) / scaleEnd * laneWidth; const x = Math.min(laneWidth - width / 2 - 2, Math.max(width / 2 + 2, pointX)); return { label, fullLabel: row[mapping.label], x, width }; }).sort((left, right) => left.x - right.x);
+        for (let index = 1; index < levels.length; index += 1) if (levels[index].x - levels[index - 1].x < (levels[index].width + levels[index - 1].width) / 2 + 4) { errors.push(`Nomogram levels “${levels[index - 1].fullLabel}” and “${levels[index].fullLabel}” overlap within predictor “${predictor}” at the current width; increase width or supply separated point assignments.`); break; }
+      });
+    }
+  }
+  if (definition.id === "km-cutoff") {
+    const invalidEvents = dataset.rows.filter((row) => ![0, 1].includes(parseNumericValue(row[mapping.event]) ?? Number.NaN)).length;
+    const invalidTimes = dataset.rows.filter((row) => (parseNumericValue(row[mapping.time]) ?? -1) < 0).length;
+    if (invalidEvents > 0) errors.push(`Event contains ${invalidEvents} value${invalidEvents === 1 ? "" : "s"} other than 0 or 1.`);
+    if (invalidTimes > 0) errors.push(`Follow-up time contains ${invalidTimes} negative or missing value${invalidTimes === 1 ? "" : "s"}.`);
+    const cutoffs = new Set(dataset.rows.map((row) => parseNumericValue(row[mapping.cutoff])));
+    if (cutoffs.size !== 1 || cutoffs.has(null)) errors.push("Cutoff KM requires one constant numeric cutoff repeated across all rows.");
+    const cutoff = [...cutoffs][0];
+    if (typeof cutoff === "number" && mapping.score) {
+      const low = dataset.rows.filter((row) => (parseNumericValue(row[mapping.score]) ?? cutoff) < cutoff).length; const high = dataset.rows.length - low;
+      if (low < 2 || high < 2) errors.push("The supplied cutoff must create two groups with at least two subjects each.");
+    }
+    warnings.push("Cutoff KM displays a supplied threshold only. If the cutoff was optimized and evaluated in the same cohort, treat the separation as exploratory and validate it independently.");
+  }
+  if (definition.id === "risk-score" && settings) {
+    const subjects = dataset.rows.map((row) => row[mapping.label]?.trim()); const blankSubjects = subjects.filter((subject) => !subject).length; const duplicateSubjects = subjects.filter((subject, index) => Boolean(subject) && subjects.indexOf(subject) !== index);
+    if (blankSubjects > 0) errors.push(`Risk-score Subject contains ${blankSubjects} blank identifier${blankSubjects === 1 ? "" : "s"}.`);
+    if (duplicateSubjects.length > 0) errors.push(`Risk-score Subject IDs must be unique; duplicated: ${[...new Set(duplicateSubjects)].slice(0, 8).join(", ")}.`);
+    const plotWidth = Math.max(100, settings.width - 88);
+    const minimumSubjectSpacing = Math.max(2.5, settings.pointSize * 0.7);
+    const maximumSubjects = Math.max(10, Math.floor(plotWidth / minimumSubjectSpacing));
+    if (dataset.rows.length > maximumSubjects) errors.push(`Risk-score marks would overlap at ${settings.width}px: ${dataset.rows.length} subjects supplied, ${maximumSubjects} fit at the current point size. Increase width or reduce point size.`);
   }
 
   if (definition.id === "survival-forest") {

--- a/tests/e2e/visualization-studio.spec.ts
+++ b/tests/e2e/visualization-studio.spec.ts
@@ -947,4 +947,93 @@ test.describe("Visualization Studio browser acceptance", () => {
     }).length);
     expect(summaryCollisions).toBe(0);
   });
+
+  test("renders clinical evaluation modules with explicit assumptions and uncertainty", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop-chromium", "Desktop clinical-evaluation acceptance");
+    await page.goto("/");
+
+    const cases = [
+      { button: /^Funnel/, type: "Funnel", element: "funnel-study", minimum: 7 },
+      { button: /^Precision–recall/, type: "Precision–recall", element: "pr-curve", minimum: 2 },
+      { button: /^Calibration/, type: "Calibration", element: "calibration-series", minimum: 2 },
+      { button: /^Decision curve/, type: "Decision curve", element: "decision-curve", minimum: 2 },
+      { button: /^Nomogram/, type: "Nomogram", element: "nomogram-point", minimum: 8 },
+      { button: /^LASSO path/, type: "LASSO path", element: "lasso-path", minimum: 3 },
+      { button: /^Cutoff KM/, type: "Cutoff KM", element: "cutoff-km", minimum: 2 },
+      { button: /^Risk-score panel/, type: "Risk-score panel", element: "risk-subject", minimum: 10 },
+    ];
+    for (const entry of cases) {
+      await page.getByRole("button", { name: entry.button }).click();
+      await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+      const svg = page.locator(`svg[aria-label='${entry.type} scientific figure preview']`);
+      expect(await svg.locator(`[data-plot-element='${entry.element}']`).count()).toBeGreaterThanOrEqual(entry.minimum);
+      expect(await svg.innerHTML()).not.toMatch(/(?:NaN|Infinity|-Infinity|undefined)/);
+      const outside = await svg.evaluate((element) => { const canvas = element.getBoundingClientRect(); return [...element.querySelectorAll<SVGGraphicsElement>("text, [data-plot-element]")].filter((mark) => { const box = mark.getBoundingClientRect(); return box.left < canvas.left - 1 || box.top < canvas.top - 1 || box.right > canvas.right + 1 || box.bottom > canvas.bottom + 1; }).length; });
+      expect(outside, entry.type).toBe(0);
+    }
+
+    await page.getByRole("button", { name: /^Cutoff KM/ }).click();
+    const cutoffKm = page.locator("svg[aria-label='Cutoff KM scientific figure preview']");
+    await expect(cutoffKm.locator("[data-step-curve='right-continuous']")).toHaveCount(2);
+    expect(await cutoffKm.locator("[data-step-curve='right-continuous']").first().getAttribute("d")).toMatch(/^M [\d.]+ [\d.]+(?: H [\d.]+ V [\d.]+)+$/);
+    expect(await cutoffKm.locator("[data-plot-element='cutoff-km-censor']").count()).toBeGreaterThan(0);
+    await expect(cutoffKm.locator("[data-plot-element='cutoff-km-censor'] title").first()).toContainText(/censored at time/);
+
+    await page.getByRole("textbox", { name: "CSV or TSV data" }).fill("sample\tscore\ttime\tevent\tcutoff\nL0\t0.1\t0\t0\t0.5\nL1\t0.2\t8\t0\t0.5\nL2\t0.3\t4\t1\t0.5\nH0\t0.7\t0\t0\t0.5\nH1\t0.8\t8\t0\t0.5\nH2\t0.9\t5\t1\t0.5");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const censorBounds = await cutoffKm.evaluate((element) => {
+      const svg = element as SVGSVGElement; const canvas = svg.getBoundingClientRect();
+      return [...svg.querySelectorAll<SVGGElement>("[data-plot-element='cutoff-km-censor']")].map((mark) => { const box = mark.getBoundingClientRect(); const horizontal = mark.querySelector<SVGLineElement>("line")!; return { left: box.left, right: box.right, top: box.top, bottom: box.bottom, canvasLeft: canvas.left, canvasRight: canvas.right, canvasTop: canvas.top, canvasBottom: canvas.bottom, clip: getComputedStyle(horizontal).clipPath, anchorX: Number(mark.dataset.censorTimeX), lineCenterX: (Number(horizontal.getAttribute("x1")) + Number(horizontal.getAttribute("x2"))) / 2 }; });
+    });
+    expect(censorBounds.length).toBeGreaterThanOrEqual(4);
+    expect(censorBounds.every((box) => box.left >= box.canvasLeft - 0.5 && box.right <= box.canvasRight + 0.5 && box.top >= box.canvasTop - 0.5 && box.bottom <= box.canvasBottom + 0.5 && box.clip === "none" && Math.abs(box.anchorX - box.lineCenterX) < 1e-6), JSON.stringify(censorBounds)).toBe(true);
+
+    await page.getByRole("button", { name: /^Precision–recall/ }).click();
+    await page.getByRole("textbox", { name: "CSV or TSV data" }).fill("sample\ttruth\tscore\tmodel\nS1\t1\t0.9\tExtremely long externally validated integrated clinical molecular model\nS2\t0\t0.2\tExtremely long externally validated integrated clinical molecular model\nS3\t1\t0.8\tSecond exceptionally long independent prediction model identity\nS4\t0\t0.1\tSecond exceptionally long independent prediction model identity");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const precisionRecall = page.locator("svg[aria-label='Precision–recall scientific figure preview']");
+    await expect(precisionRecall.locator("text[data-full-label]").first()).toContainText("…");
+    const escapedModelLabels = await precisionRecall.evaluate((element) => { const canvas = element.getBoundingClientRect(); return [...element.querySelectorAll<SVGTextElement>("text[data-full-label]")].filter((label) => { const box = label.getBoundingClientRect(); return box.left < canvas.left - 1 || box.right > canvas.right + 1; }).length; });
+    expect(escapedModelLabels).toBe(0);
+
+    await page.getByRole("button", { name: /^LASSO path/ }).click();
+    const lassoRows = ["lambda\tcoefficient\tfeature", ...Array.from({ length: 12 }, (_, feature) => [1, 0.1].map((lambda, point) => `${lambda}\t${(feature + 1) * (point + 1) / 20}\t宽字符临床分子特征名称 ${String(feature + 1).padStart(2, "0")} extraordinarily long suffix`).join("\n"))].join("\n");
+    await page.getByRole("textbox", { name: "CSV or TSV data" }).fill(lassoRows);
+    const legendSize = page.getByRole("textbox", { name: "Legend size value" });
+    await legendSize.fill("16"); await legendSize.press("Enter");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const lasso = page.locator("svg[aria-label='LASSO path scientific figure preview']");
+    const lassoLayout = await lasso.evaluate((element) => { const canvas = element.getBoundingClientRect(); const labels = [...element.querySelectorAll<SVGTextElement>("text[data-full-label]")].map((label) => label.getBoundingClientRect()).sort((a, b) => a.top - b.top); return { collisions: labels.filter((label, index) => index > 0 && label.top < labels[index - 1].bottom - 0.5).length, escaped: labels.filter((label) => label.left < canvas.left - 0.5 || label.right > canvas.right + 0.5).length }; });
+    expect(lassoLayout).toEqual({ collisions: 0, escaped: 0 });
+
+    await page.getByRole("button", { name: /^Nomogram/ }).click();
+    await page.getByRole("textbox", { name: "CSV or TSV data" }).fill("predictor\tlevel\tpoints\nStage\tNearly identical level alpha\t10\nStage\tNearly identical level beta\t10.1");
+    await expect(page.getByText(/overlap within predictor/)).toBeVisible();
+    await expect(page.getByRole("button", { name: "SVG" })).toBeDisabled();
+    await page.getByRole("textbox", { name: "CSV or TSV data" }).fill("predictor\tlevel\tpoints\nStage\tVery long zero-point boundary label\t0\nStage\tMiddle\t50\nBiomarker\tVery long maximum boundary label\t100\nBiomarker\tQuarter\t25");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const nomogram = page.locator("svg[aria-label='Nomogram scientific figure preview']");
+    const nomogramEscapes = await nomogram.evaluate((element) => { const svg = element as SVGSVGElement; const clip = svg.querySelector<SVGRectElement>("clipPath rect")!; const left = Number(clip.getAttribute("x")); const right = left + Number(clip.getAttribute("width")); return [...svg.querySelectorAll<SVGTextElement>("text[data-full-label]")].filter((label) => { if (["Stage", "Biomarker"].includes(label.dataset.fullLabel ?? "")) return false; const box = label.getBBox(); return box.x < left - 0.5 || box.x + box.width > right + 0.5; }).length; });
+    expect(nomogramEscapes).toBe(0);
+
+    await page.getByRole("button", { name: /^ROC/ }).click();
+    await page.getByRole("button", { name: /Example 2.*Time-dependent/ }).click();
+    await expect(page.getByRole("combobox", { name: "Input structure" })).toHaveValue("precomputed-time");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    const roc = page.locator("svg[aria-label='ROC scientific figure preview']");
+    await expect(roc.locator("[data-plot-element='time-dependent-roc']")).toHaveCount(4);
+    await expect(roc.locator("[data-auc-interval]")).toHaveCount(4);
+    await expect(roc.locator("[data-auc-interval]").first()).toContainText(/AUC.*\[.*–.*\]/);
+
+    await page.getByRole("button", { name: /^Decision curve/ }).click();
+    await page.getByRole("textbox", { name: "Minimum threshold value" }).fill("0.01");
+    await page.getByRole("textbox", { name: "Minimum threshold value" }).press("Enter");
+    await page.getByRole("textbox", { name: "Grid resolution value" }).fill("0.01");
+    await page.getByRole("textbox", { name: "Grid resolution value" }).press("Enter");
+    const decisionSvg = page.locator("svg[aria-label='Decision curve scientific figure preview']");
+    await expect(decisionSvg.locator("[data-plot-element='decision-threshold-grid']")).toContainText("Grid 0.010–0.800 · Δ 0.010");
+    await page.getByRole("textbox", { name: "CSV or TSV data" }).fill("truth\tscore\tmodel\n1\t1.2\tModel\n0\t0.2\tModel");
+    await expect(page.getByText(/Predicted probability contains 1 value outside \[0, 1\]/)).toBeVisible();
+    await expect(page.getByRole("button", { name: "SVG" })).toBeDisabled();
+  });
 });


### PR DESCRIPTION
Closes #15

Adds funnel, precision–recall, calibration, decision-curve, nomogram, LASSO path, supplied-cutoff Kaplan–Meier, and risk-score panels, while extending ROC to raw multi-model and supplied time-dependent confidence-interval inputs.

Scientific safeguards include tied-score invariant PR/AP and calibration bins, shared-cohort DCA validation with configurable threshold grids, right-continuous KM steps with censoring, pixel-safe compact labels, strict LASSO trajectory contracts, and explicit supplied/upstream-method caveats.

Verified locally:
- `npm run typecheck`
- `npm run lint`
- `npm test -- --run` (161 passed)
- `npx playwright test` (17 passed, 11 expected mobile skips)
- `npx next build --webpack`
- independent specification review: Clean
- independent standards/layout review: Clean