### PR TITLE
Fix line time ticks and add pointwise significance

### DIFF
--- a/src/components/ScientificAdvancedChartPreview.tsx
+++ b/src/components/ScientificAdvancedChartPreview.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/visualization-advanced";
 import {
   alignHeatmapAnnotations,
+  benjaminiHochbergAdjust,
   categoricalColorForIndex,
   boxStatistics,
   confidenceInterval95,
@@ -43,6 +44,7 @@ import {
   loessSmooth,
   meanErrorStatistics,
   numericExtent,
+  observedAxisTicks,
   ordinationAnnotationLayout,
   ordinationFrameMetrics,
   ordinationLegendLayout,
@@ -53,6 +55,7 @@ import {
   polynomialRegression,
   resolveAxisDomain,
   scaleLinear,
+  welchSummaryPValue,
   type JournalThemeId,
   type OrdinationType,
   type ParsedDataset,
@@ -101,10 +104,10 @@ function tickValues(domain: [number, number], count = 5) {
   return Array.from({ length: count }, (_, index) => domain[0] + (domain[1] - domain[0]) * index / Math.max(1, count - 1));
 }
 
-function Axes({ frame, settings, xDomain, yDomain, xLabel, yLabel, gridColor, hideXTicks = false, hideYTicks = false, categoryXPositions, categoryYPositions }: { frame: Frame; settings: VisualizationSettings; xDomain: [number, number]; yDomain: [number, number]; xLabel: string; yLabel: string; gridColor: string; hideXTicks?: boolean; hideYTicks?: boolean; categoryXPositions?: number[]; categoryYPositions?: number[] }) {
+function Axes({ frame, settings, xDomain, yDomain, xLabel, yLabel, gridColor, hideXTicks = false, hideYTicks = false, categoryXPositions, categoryYPositions, xTickValues, yTickValues }: { frame: Frame; settings: VisualizationSettings; xDomain: [number, number]; yDomain: [number, number]; xLabel: string; yLabel: string; gridColor: string; hideXTicks?: boolean; hideYTicks?: boolean; categoryXPositions?: number[]; categoryYPositions?: number[]; xTickValues?: number[]; yTickValues?: number[] }) {
   const bottom = frame.top + frame.plotHeight;
-  const xTicks = tickValues(xDomain, Math.max(3, Math.min(6, Math.floor(frame.plotWidth / 90))));
-  const yTicks = tickValues(yDomain, Math.max(3, Math.min(6, Math.floor(frame.plotHeight / 70))));
+  const xTicks = xTickValues ?? tickValues(xDomain, Math.max(3, Math.min(6, Math.floor(frame.plotWidth / 90))));
+  const yTicks = yTickValues ?? tickValues(yDomain, Math.max(3, Math.min(6, Math.floor(frame.plotHeight / 70))));
   const verticalGridPositions = categoryXPositions
     ?? (hideXTicks ? [] : xTicks.map((value) => scaleLinear(value, xDomain, [frame.left, frame.left + frame.plotWidth])));
   const horizontalGridPositions = categoryYPositions
@@ -114,10 +117,10 @@ function Axes({ frame, settings, xDomain, yDomain, xLabel, yLabel, gridColor, hi
     {settings.grid !== "none" ? horizontalGridPositions.map((y) => <line key={`gy-${y}`} data-grid-axis="y" x1={frame.left} x2={frame.left + frame.plotWidth} y1={y} y2={y} stroke={gridColor} strokeWidth={settings.gridLineWidth} />) : null}
     <line x1={frame.left} x2={frame.left + frame.plotWidth} y1={bottom} y2={bottom} stroke={TEXT} strokeWidth={settings.axisLineWidth} />
     <line x1={frame.left} x2={frame.left} y1={frame.top} y2={bottom} stroke={TEXT} strokeWidth={settings.axisLineWidth} />
-    {!hideXTicks ? xTicks.map((value) => { const x = scaleLinear(value, xDomain, [frame.left, frame.left + frame.plotWidth]); return <g key={`xt-${value}`}><line x1={x} x2={x} y1={bottom} y2={bottom + 5} stroke={TEXT} strokeWidth={settings.axisLineWidth} /><text x={x} y={bottom + 19} textAnchor="middle" fill={TEXT} fontSize={settings.tickSize}>{formatTick(value)}</text></g>; }) : null}
-    {!hideYTicks ? yTicks.map((value) => { const y = scaleLinear(value, yDomain, [bottom, frame.top]); return <g key={`yt-${value}`}><line x1={frame.left - 5} x2={frame.left} y1={y} y2={y} stroke={TEXT} strokeWidth={settings.axisLineWidth} /><text x={frame.left - 9} y={y + 4} textAnchor="end" fill={TEXT} fontSize={settings.tickSize}>{formatTick(value)}</text></g>; }) : null}
-    {xLabel ? <text x={frame.left + frame.plotWidth / 2} y={frame.height - (settings.legendPosition === "bottom" ? 47 : 13)} textAnchor="middle" fill={TEXT} fontSize={settings.axisLabelSize} fontWeight={600}>{xLabel}</text> : null}
-    {yLabel ? <text transform={`translate(18 ${frame.top + frame.plotHeight / 2}) rotate(-90)`} textAnchor="middle" fill={TEXT} fontSize={settings.axisLabelSize} fontWeight={600}>{yLabel}</text> : null}
+    {!hideXTicks ? xTicks.map((value) => { const x = scaleLinear(value, xDomain, [frame.left, frame.left + frame.plotWidth]); return <g key={`xt-${value}`}><line x1={x} x2={x} y1={bottom} y2={bottom + 5} stroke={TEXT} strokeWidth={settings.axisLineWidth} /><text data-axis-tick="x" x={x} y={bottom + 19} textAnchor="middle" fill={TEXT} fontSize={settings.tickSize}>{formatTick(value)}</text></g>; }) : null}
+    {!hideYTicks ? yTicks.map((value) => { const y = scaleLinear(value, yDomain, [bottom, frame.top]); return <g key={`yt-${value}`}><line x1={frame.left - 5} x2={frame.left} y1={y} y2={y} stroke={TEXT} strokeWidth={settings.axisLineWidth} /><text data-axis-tick="y" x={frame.left - 9} y={y + 4} textAnchor="end" fill={TEXT} fontSize={settings.tickSize}>{formatTick(value)}</text></g>; }) : null}
+    {xLabel ? <text data-axis-label="x" x={frame.left + frame.plotWidth / 2} y={frame.height - (settings.legendPosition === "bottom" ? 47 : 13)} textAnchor="middle" fill={TEXT} fontSize={settings.axisLabelSize} fontWeight={600}>{xLabel}</text> : null}
+    {yLabel ? <text data-axis-label="y" transform={`translate(18 ${frame.top + frame.plotHeight / 2}) rotate(-90)`} textAnchor="middle" fill={TEXT} fontSize={settings.axisLabelSize} fontWeight={600}>{yLabel}</text> : null}
   </g>;
 }
 
@@ -153,7 +156,7 @@ function LineAssociationPlot({ frame, dataset, mapping, settings, colors, gridCo
   const rows = dataset.rows.map((row, index) => {
     const rawX = parseNumericValue(row[mapping.x]) ?? 0;
     const rawY = parseNumericValue(row[mapping.value]) ?? 0;
-    return { x: settings.swapAxes ? rawY : rawX, y: settings.swapAxes ? rawX : rawY, error: settings.lineErrorType !== "none" && mapping.error ? Math.max(0, parseNumericValue(row[mapping.error]) ?? 0) : 0, group: mapping.series ? row[mapping.series] || "All" : "All", index };
+    return { x: settings.swapAxes ? rawY : rawX, y: settings.swapAxes ? rawX : rawY, rawX, mean: rawY, error: settings.lineErrorType !== "none" && mapping.error ? Math.max(0, parseNumericValue(row[mapping.error]) ?? 0) : 0, n: mapping.n ? parseNumericValue(row[mapping.n]) : null, group: mapping.series ? row[mapping.series] || "All" : "All", index };
   });
   const groups = [...new Set(rows.map((row) => row.group))];
   const colorMap = palette(groups, colors);
@@ -162,14 +165,32 @@ function LineAssociationPlot({ frame, dataset, mapping, settings, colors, gridCo
   const yDomain = resolveAxisDomain(numericExtent(settings.swapAxes ? rows.map((row) => row.y) : valueExtent), settings.yMin, settings.yMax);
   const xAt = (value: number) => scaleLinear(value, xDomain, [frame.left, frame.left + frame.plotWidth]);
   const yAt = (value: number) => scaleLinear(value, yDomain, [frame.top + frame.plotHeight, frame.top]);
+  const maximumTimeTicks = Math.max(2, Math.min(12, Math.floor((settings.swapAxes ? frame.plotHeight : frame.plotWidth) / Math.max(24, settings.tickSize * 2.2))));
+  const timeTicks = observedAxisTicks(rows.map((row) => row.rawX), maximumTimeTicks);
+  const referenceSeries = settings.lineReferenceSeries && groups.includes(settings.lineReferenceSeries) ? settings.lineReferenceSeries : groups[0];
+  const rawComparisons = settings.showSignificance && (settings.lineErrorType === "sd" || settings.lineErrorType === "sem")
+    ? rows.flatMap((row) => {
+        if (row.group === referenceSeries || row.n === null) return [];
+        const reference = rows.find((candidate) => candidate.group === referenceSeries && candidate.rawX === row.rawX && candidate.n !== null);
+        if (!reference || reference.n === null) return [];
+        const rowSd = settings.lineErrorType === "sem" ? row.error * Math.sqrt(row.n) : row.error;
+        const referenceSd = settings.lineErrorType === "sem" ? reference.error * Math.sqrt(reference.n) : reference.error;
+        const pValue = welchSummaryPValue(row.mean, rowSd, row.n, reference.mean, referenceSd, reference.n);
+        return pValue === null ? [] : [{ rowIndex: row.index, pValue }];
+      })
+    : [];
+  const adjustedPValues = settings.linePAdjustment === "bh" ? benjaminiHochbergAdjust(rawComparisons.map((comparison) => comparison.pValue)) : rawComparisons.map((comparison) => comparison.pValue);
+  const significanceByRow = new Map(rawComparisons.map((comparison, index) => [comparison.rowIndex, adjustedPValues[index]]));
+  const significanceLabel = (pValue: number) => pValue <= 0.001 ? "***" : pValue <= 0.01 ? "**" : pValue <= settings.significanceThreshold ? "*" : "ns";
   return <>
-    <Axes frame={frame} settings={settings} xDomain={xDomain} yDomain={yDomain} xLabel={settings.xLabel || (settings.swapAxes ? "Value" : "X")} yLabel={settings.yLabel || (settings.swapAxes ? "X" : "Value")} gridColor={gridColor} />
+    <Axes frame={frame} settings={settings} xDomain={xDomain} yDomain={yDomain} xLabel={settings.swapAxes ? settings.yLabel.trim() : settings.xLabel.trim()} yLabel={settings.swapAxes ? settings.xLabel.trim() : settings.yLabel.trim()} gridColor={gridColor} xTickValues={settings.swapAxes ? undefined : timeTicks} yTickValues={settings.swapAxes ? timeTicks : undefined} />
     <g data-plot-data data-plot-family="line-association">
       {groups.map((group) => { const groupRows = rows.filter((row) => row.group === group).sort((left, right) => (settings.swapAxes ? left.y - right.y : left.x - right.x) || left.index - right.index); const color = colorMap.get(group) ?? colors[0]; const upper = groupRows.map((row) => settings.swapAxes ? `${xAt(row.x + row.error)},${yAt(row.y)}` : `${xAt(row.x)},${yAt(row.y + row.error)}`); const lower = [...groupRows].reverse().map((row) => settings.swapAxes ? `${xAt(row.x - row.error)},${yAt(row.y)}` : `${xAt(row.x)},${yAt(row.y - row.error)}`); return <g key={group}>
         {settings.lineErrorType !== "none" && settings.lineUncertaintyStyle === "band" ? <polygon data-plot-element="line-uncertainty-band" points={[...upper, ...lower].join(" ")} fill={color} fillOpacity={settings.lineBandOpacity} stroke="none" /> : null}
         <polyline data-plot-element="line-series" points={groupRows.map((row) => `${xAt(row.x)},${yAt(row.y)}`).join(" ")} fill="none" stroke={color} strokeWidth={settings.dataLineWidth} strokeLinejoin="round" strokeLinecap="round" />
         {settings.lineErrorType !== "none" && settings.lineUncertaintyStyle === "bars" ? groupRows.map((row) => settings.swapAxes ? <g key={row.index} data-plot-element="line-uncertainty-bar" stroke={color} strokeWidth={settings.errorBarLineWidth}><line x1={xAt(row.x - row.error)} x2={xAt(row.x + row.error)} y1={yAt(row.y)} y2={yAt(row.y)} /><line x1={xAt(row.x - row.error)} x2={xAt(row.x - row.error)} y1={yAt(row.y) - settings.errorBarCapSize / 2} y2={yAt(row.y) + settings.errorBarCapSize / 2} /><line x1={xAt(row.x + row.error)} x2={xAt(row.x + row.error)} y1={yAt(row.y) - settings.errorBarCapSize / 2} y2={yAt(row.y) + settings.errorBarCapSize / 2} /></g> : <g key={row.index} data-plot-element="line-uncertainty-bar" stroke={color} strokeWidth={settings.errorBarLineWidth}><line x1={xAt(row.x)} x2={xAt(row.x)} y1={yAt(row.y - row.error)} y2={yAt(row.y + row.error)} /><line x1={xAt(row.x) - settings.errorBarCapSize / 2} x2={xAt(row.x) + settings.errorBarCapSize / 2} y1={yAt(row.y - row.error)} y2={yAt(row.y - row.error)} /><line x1={xAt(row.x) - settings.errorBarCapSize / 2} x2={xAt(row.x) + settings.errorBarCapSize / 2} y1={yAt(row.y + row.error)} y2={yAt(row.y + row.error)} /></g>) : null}
         {settings.showPoints ? groupRows.map((row) => <circle key={row.index} data-plot-element="line-point" cx={xAt(row.x)} cy={yAt(row.y)} r={settings.pointSize} fill={color} stroke="#FFFFFF" strokeWidth={0.7} />) : null}
+        {settings.showSignificance ? groupRows.map((row) => { const adjustedPValue = significanceByRow.get(row.index); if (adjustedPValue === undefined) return null; const labelX = settings.swapAxes ? xAt(row.x + row.error) + 8 : xAt(row.x); const labelY = settings.swapAxes ? yAt(row.y) + 4 : Math.max(frame.top + settings.tickSize, yAt(row.y + row.error) - 7); return <text key={`line-significance-${row.index}`} data-plot-element="line-significance" data-adjusted-p={adjustedPValue.toPrecision(6)} x={labelX} y={labelY} textAnchor={settings.swapAxes ? "start" : "middle"} fill={color} fillOpacity={adjustedPValue <= settings.significanceThreshold ? 1 : 0.62} fontSize={settings.tickSize} fontWeight={700}><title>{`${row.group} vs ${referenceSeries}; ${settings.linePAdjustment === "bh" ? "BH-adjusted " : ""}P=${adjustedPValue.toPrecision(4)}`}</title>{significanceLabel(adjustedPValue)}</text>; }) : null}
       </g>; })}
     </g>
     <Legend entries={groups.map((group) => ({ label: group, color: colorMap.get(group) ?? colors[0] }))} frame={frame} settings={settings} />

--- a/src/components/ScientificChartPreview.tsx
+++ b/src/components/ScientificChartPreview.tsx
@@ -4,6 +4,7 @@ import type { ReactNode, RefObject } from "react";
 import { ScientificAdvancedChartPreview } from "@/components/ScientificAdvancedChartPreview";
 import {
   BAR_CATEGORY_LABEL_ANGLE,
+  benjaminiHochbergAdjust,
   barCategoryAxisLayoutMetrics,
   barCategoryLabelText,
   boxStatistics,
@@ -19,10 +20,12 @@ import {
   linearRegression,
   meanErrorStatistics,
   numericExtent,
+  observedAxisTicks,
   parseNumericValue,
   parseRatioValue,
   resolveAxisDomain,
   scaleLinear,
+  welchSummaryPValue,
   type JournalThemeId,
   type ParsedDataset,
   type PlotType,
@@ -154,7 +157,7 @@ function NumericAxes({
         return (
           <g key={`xt-${value}`}>
             <line x1={x} x2={x} y1={xBottom} y2={xBottom + 5} stroke={ink} strokeWidth={settings.axisLineWidth} />
-            <text x={x} y={xBottom + 19} textAnchor="middle" fill={muted} fontSize={settings.tickSize}>{formatTick(value)}</text>
+            <text data-axis-tick="x" x={x} y={xBottom + 19} textAnchor="middle" fill={muted} fontSize={settings.tickSize}>{formatTick(value)}</text>
           </g>
         );
       }) : null}
@@ -163,7 +166,7 @@ function NumericAxes({
         return (
           <g key={`yt-${value}`}>
             <line x1={frame.left - 5} x2={frame.left} y1={y} y2={y} stroke={ink} strokeWidth={settings.axisLineWidth} />
-            <text x={frame.left - 9} y={y + settings.tickSize * 0.34} textAnchor="end" fill={muted} fontSize={settings.tickSize}>{formatTick(value)}</text>
+            <text data-axis-tick="y" x={frame.left - 9} y={y + settings.tickSize * 0.34} textAnchor="end" fill={muted} fontSize={settings.tickSize}>{formatTick(value)}</text>
           </g>
         );
       }) : null}
@@ -395,7 +398,9 @@ function renderLineOrScatter(
     return {
       x: settings.swapAxes ? rawY : rawX,
       y: settings.swapAxes ? rawX : rawY,
+      mean: rawY,
       error: lineErrorsEnabled && mapping.error ? Math.max(0, parseNumericValue(row[mapping.error]) ?? 0) : 0,
+      n: mapping.n ? parseNumericValue(row[mapping.n]) : null,
       group: row[type === "line" ? mapping.series : mapping.group] || "All",
       label: type !== "line" && mapping.label ? row[mapping.label] : "",
       index,
@@ -410,12 +415,32 @@ function renderLineOrScatter(
     : points.map((point) => point.y)), settings.yMin, settings.yMax);
   const groups = [...new Set(points.map((point) => point.group))];
   const colorMap = paletteForGroups(groups, colors);
+  const referenceSeries = settings.lineReferenceSeries && groups.includes(settings.lineReferenceSeries) ? settings.lineReferenceSeries : groups[0];
+  const rawLineComparisons = type === "line" && settings.showSignificance && (settings.lineErrorType === "sd" || settings.lineErrorType === "sem")
+    ? points.flatMap((point) => {
+        if (point.group === referenceSeries || point.n === null) return [];
+        const reference = points.find((candidate) => candidate.group === referenceSeries && candidate.order === point.order && candidate.n !== null);
+        if (!reference || reference.n === null) return [];
+        const pointSd = settings.lineErrorType === "sem" ? point.error * Math.sqrt(point.n) : point.error;
+        const referenceSd = settings.lineErrorType === "sem" ? reference.error * Math.sqrt(reference.n) : reference.error;
+        const pValue = welchSummaryPValue(point.mean, pointSd, point.n, reference.mean, referenceSd, reference.n);
+        return pValue === null ? [] : [{ pointIndex: point.index, pValue }];
+      })
+    : [];
+  const adjustedLinePValues = settings.linePAdjustment === "bh"
+    ? benjaminiHochbergAdjust(rawLineComparisons.map((comparison) => comparison.pValue))
+    : rawLineComparisons.map((comparison) => comparison.pValue);
+  const lineSignificance = new Map(rawLineComparisons.map((comparison, index) => [comparison.pointIndex, { ...comparison, adjustedPValue: adjustedLinePValues[index] }]));
+  const maximumObservedTicks = Math.max(2, Math.min(12, Math.floor((settings.swapAxes ? frame.plotHeight : frame.plotWidth) / Math.max(24, settings.tickSize * 2.2))));
+  const lineTimeTicks = type === "line"
+    ? observedAxisTicks(points.map((point) => settings.swapAxes ? point.y : point.x), maximumObservedTicks)
+    : undefined;
   const xLabel = settings.swapAxes
-    ? settings.yLabel || (type === "line" ? "Value" : "Y")
-    : settings.xLabel || "X";
+    ? settings.yLabel.trim()
+    : settings.xLabel.trim();
   const yLabel = settings.swapAxes
-    ? settings.xLabel || "X"
-    : settings.yLabel || (type === "line" ? "Value" : "Y");
+    ? settings.xLabel.trim()
+    : settings.yLabel.trim();
   const scaled = points.map((point) => ({
     ...point,
     sx: scaleLinear(point.x, xDomain, [frame.left, frame.left + frame.plotWidth]),
@@ -424,7 +449,7 @@ function renderLineOrScatter(
 
   return (
     <>
-      <NumericAxes frame={frame} settings={settings} xDomain={xDomain} yDomain={yDomain} xLabel={xLabel} yLabel={yLabel} ink={ink} muted={muted} gridColor={gridColor} />
+      <NumericAxes frame={frame} settings={settings} xDomain={xDomain} yDomain={yDomain} xLabel={xLabel} yLabel={yLabel} ink={ink} muted={muted} gridColor={gridColor} xTickValues={type === "line" && !settings.swapAxes ? lineTimeTicks : undefined} yTickValues={type === "line" && settings.swapAxes ? lineTimeTicks : undefined} />
       <g data-plot-data>
       {lineErrorsEnabled
         ? scaled.map((point) => {
@@ -484,6 +509,15 @@ function renderLineOrScatter(
           {settings.showLabels && point.label ? <text data-plot-label x={point.x > (xDomain[0] + xDomain[1]) / 2 ? point.sx - settings.pointSize - 2 : point.sx + settings.pointSize + 2} y={point.y > (yDomain[0] + yDomain[1]) / 2 ? point.sy + settings.tickSize + 2 + (point.index % 2) * 3 : point.sy - 3 - (point.index % 2) * 3} textAnchor={point.x > (xDomain[0] + xDomain[1]) / 2 ? "end" : "start"} fill={ink} fontSize={settings.tickSize}>{truncate(point.label, 12)}</text> : null}
         </g>
       ))}
+      {type === "line" ? scaled.map((point) => {
+        const comparison = lineSignificance.get(point.index);
+        if (!comparison) return null;
+        const mark = comparison.adjustedPValue <= 0.001 ? "***" : comparison.adjustedPValue <= 0.01 ? "**" : comparison.adjustedPValue <= settings.significanceThreshold ? "*" : "ns";
+        const offset = settings.pointSize + settings.errorBarCapSize / 2 + settings.tickSize;
+        const x = settings.swapAxes ? Math.min(frame.left + frame.plotWidth - 4, point.sx + offset) : point.sx;
+        const y = settings.swapAxes ? point.sy + settings.tickSize * 0.3 : Math.max(frame.top + settings.tickSize, point.sy - offset);
+        return <text key={`line-significance-${point.index}`} data-plot-element="line-significance" data-adjusted-p={comparison.adjustedPValue.toPrecision(5)} x={x} y={y} textAnchor={settings.swapAxes ? "start" : "middle"} fill={ink} fillOpacity={comparison.adjustedPValue <= settings.significanceThreshold ? 1 : 0.62} fontSize={settings.tickSize} fontWeight={700}><title>{`${point.group} vs ${referenceSeries}; ${settings.linePAdjustment === "bh" ? "BH-adjusted " : ""}P=${comparison.adjustedPValue.toPrecision(4)}`}</title>{mark}</text>;
+      }) : null}
       </g>
       <Legend frame={frame} settings={settings} ink={ink} items={groups.map((group) => ({ label: group, color: colorMap.get(group) ?? colors[0], shape: type === "line" ? "line" : "circle" }))} />
     </>

--- a/src/components/VisualizationStudio.tsx
+++ b/src/components/VisualizationStudio.tsx
@@ -552,6 +552,9 @@ export function VisualizationStudio() {
   const invalidYLimits = manualAxes.includes("y") && settings.yMin !== null && settings.yMax !== null && settings.yMin >= settings.yMax;
   const pcaAnalysis = useMemo(() => plotType === "pca" && pcaInputMode === "matrix" ? analyzeExpressionMatrix(rawData, pcaOptions, pcaObservationMetadata) : null, [plotType, pcaInputMode, rawData, pcaObservationMetadata, pcaOptions]);
   const dataset = useMemo(() => pcaAnalysis?.dataset ?? parseDelimitedData(rawData), [pcaAnalysis, rawData]);
+  const lineSeriesOptions = useMemo(() => plotType === "line" && mapping.series
+    ? [...new Set(dataset.rows.map((row) => row[mapping.series]).filter(Boolean))]
+    : [], [dataset.rows, mapping.series, plotType]);
   const setAnalysis = useMemo(
     () => (plotType === "venn" || plotType === "upset") ? analyzeSetIntersections(dataset.rows, mapping, settings.setInputMode) : null,
     [dataset.rows, mapping, plotType, settings.setInputMode],
@@ -1167,6 +1170,16 @@ export function VisualizationStudio() {
             {plotType === "line" || (plotType === "bar" && !["stacked", "percentage", "polar"].includes(settings.barVariant)) ? <ControlGroup title={`${plotType === "bar" ? "Bar" : "Line"} uncertainty`}>
               <SelectControl label="Error representation" value={plotType === "bar" ? settings.barErrorType : settings.lineErrorType} onChange={(value) => selectErrorType(plotType === "bar" ? "barErrorType" : "lineErrorType", value as VisualizationSettings["barErrorType"] | VisualizationSettings["lineErrorType"])}><option value="none">None</option><option value="sd">Mean ± SD</option><option value="sem">Mean ± SEM</option>{plotType === "line" ? <option value="ci95">95% CI half-width</option> : null}</SelectControl>
               {(plotType === "bar" ? settings.barErrorType : settings.lineErrorType) !== "none" ? <>{plotType === "line" ? <SelectControl label="Display style" value={settings.lineUncertaintyStyle} onChange={(value) => updateSetting("lineUncertaintyStyle", value as VisualizationSettings["lineUncertaintyStyle"])}><option value="bars">Pointwise bars</option><option value="band">Ribbon</option></SelectControl> : null}{plotType === "line" && settings.lineUncertaintyStyle === "band" ? <RangeControl label="Ribbon opacity" value={settings.lineBandOpacity} minimum={0.04} maximum={0.5} step={0.01} onChange={(value) => updateSetting("lineBandOpacity", value)} /> : <><RangeControl label="Error line" value={settings.errorBarLineWidth} minimum={0.8} maximum={3} step={0.1} unit=" px" onChange={(value) => updateSetting("errorBarLineWidth", value)} /><RangeControl label="Cap width" value={settings.errorBarCapSize} minimum={4} maximum={30} step={1} unit=" px" onChange={(value) => updateSetting("errorBarCapSize", value)} /></>}<p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Map an already-calculated non-negative half-width. SD describes spread, SEM describes mean precision, and a 95% CI half-width describes an interval around the estimate. A ribbon changes only the display, not the statistic.</p></> : null}
+            </ControlGroup> : null}
+
+            {plotType === "line" ? <ControlGroup title="Pointwise significance">
+              <ToggleControl label="Calculate significance" checked={settings.showSignificance} onChange={(value) => updateSetting("showSignificance", value)} />
+              {settings.showSignificance ? <>
+                <SelectControl label="Reference series" value={settings.lineReferenceSeries || lineSeriesOptions[0] || ""} onChange={(value) => updateSetting("lineReferenceSeries", value)}>{lineSeriesOptions.map((series) => <option key={series} value={series}>{series}</option>)}</SelectControl>
+                <SelectControl label="Multiple-testing correction" value={settings.linePAdjustment} onChange={(value) => updateSetting("linePAdjustment", value as VisualizationSettings["linePAdjustment"])}><option value="bh">Benjamini–Hochberg FDR</option><option value="none">None</option></SelectControl>
+                <RangeControl label="Adjusted P threshold" value={settings.significanceThreshold} minimum={0.001} maximum={0.1} step={0.001} onChange={(value) => updateSetting("significanceThreshold", value)} />
+                <p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">At each X value, every non-reference series is compared with the selected reference using an independent-samples Welch t test. Map mean, SD or SEM, and an explicit integer n ≥ 2. BH correction is applied across all displayed pointwise comparisons. Do not use this calculation for paired or repeated-measures data; supply results from the appropriate upstream model instead.</p>
+              </> : null}
             </ControlGroup> : null}
 
             {plotType === "bar" ? <>

--- a/src/lib/visualization-studio.test.ts
+++ b/src/lib/visualization-studio.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   alignHeatmapAnnotations,
   barCategoryAxisLayoutMetrics,
+  benjaminiHochbergAdjust,
   analysisProvenanceForPlot,
   categoricalColorForIndex,
   boxStatistics,
@@ -26,6 +27,7 @@ import {
   loessSmooth,
   meanErrorStatistics,
   numericExtent,
+  observedAxisTicks,
   ordinationLoadingLayout,
   ordinationLegendLayout,
   parseDelimitedData,
@@ -33,10 +35,12 @@ import {
   polynomialRegression,
   resolveAxisDomain,
   studentTCritical95,
+  studentTTwoSidedPValue,
   plotDefinitions,
   plotGuidance,
   plotReferences,
   validatePlotDataset,
+  welchSummaryPValue,
 } from "./visualization-studio";
 
 function relativeLuminance(hex: string) {
@@ -51,6 +55,38 @@ function rgbChroma(hex: string) {
 }
 
 describe("Visualization Studio data contracts", () => {
+  it("uses actual ordered sampling times when a line axis can display them clearly", () => {
+    expect(observedAxisTicks([0, 1, 2, 3, 0, 1, 2, 3], 8)).toEqual([0, 1, 2, 3]);
+    expect(observedAxisTicks([3, 1, 2, 0], 8)).toEqual([0, 1, 2, 3]);
+    expect(observedAxisTicks(Array.from({ length: 20 }, (_, index) => index), 8)).toBeUndefined();
+  });
+
+  it("calculates Welch summary P values and BH-adjusted pointwise comparisons", () => {
+    expect(studentTTwoSidedPValue(2.228, 10)).toBeCloseTo(0.05, 3);
+    expect(welchSummaryPValue(1, 0.2, 3, 1, 0.3, 3)).toBe(1);
+    expect((welchSummaryPValue(1, 0.2, 3, 2, 0.2, 3) ?? 1) < 0.01).toBe(true);
+    expect(benjaminiHochbergAdjust([0.01, 0.04, 0.03])).toEqual([0.03, 0.04, 0.04]);
+  });
+
+  it("requires explicit n and SD or SEM for line significance calculation", () => {
+    const definition = getPlotDefinition("line");
+    const withoutN = validatePlotDataset(
+      definition,
+      parseDelimitedData("time\tvalue\tsd\tseries\n0\t1\t0.1\tA\n0\t2\t0.2\tB"),
+      { x: "time", value: "value", error: "sd", n: "", series: "series" },
+      { ...defaultVisualizationSettings, lineErrorType: "sd", showSignificance: true },
+    );
+    expect(withoutN.errors).toContain("Map an explicit sample-size (n) column before calculating line significance.");
+
+    const valid = validatePlotDataset(
+      definition,
+      parseDelimitedData("time\tvalue\tsd\tn\tseries\n0\t1\t0.1\t3\tA\n0\t2\t0.2\t3\tB"),
+      { x: "time", value: "value", error: "sd", n: "n", series: "series" },
+      { ...defaultVisualizationSettings, lineErrorType: "sd", showSignificance: true },
+    );
+    expect(valid.errors).toEqual([]);
+  });
+
   it("reports whether analysis results were supplied or calculated in Studio", () => {
     expect(analysisProvenanceForPlot("pca", defaultVisualizationSettings, "scores")?.source).toBe("supplied");
     expect(analysisProvenanceForPlot("pca", defaultVisualizationSettings, "matrix")?.source).toBe("calculated-in-studio");

--- a/src/lib/visualization-studio.ts
+++ b/src/lib/visualization-studio.ts
@@ -355,6 +355,8 @@ export type VisualizationSettings = {
   lineErrorType: "none" | "sd" | "sem" | "ci95";
   lineUncertaintyStyle: "bars" | "band";
   lineBandOpacity: number;
+  lineReferenceSeries: string;
+  linePAdjustment: "none" | "bh";
   associationVariant: "points" | "marginal" | "density" | "hexbin" | "ellipse" | "hull" | "pair-matrix" | "3d" | "ternary";
   associationFit: "none" | "linear" | "polynomial" | "loess";
   associationPolynomialDegree: 2 | 3;
@@ -493,6 +495,8 @@ export const defaultVisualizationSettings: VisualizationSettings = {
   lineErrorType: "none",
   lineUncertaintyStyle: "bars",
   lineBandOpacity: 0.16,
+  lineReferenceSeries: "",
+  linePAdjustment: "bh",
   associationVariant: "points",
   associationFit: "none",
   associationPolynomialDegree: 2,
@@ -1566,15 +1570,15 @@ Day 7\t7.2\t0.54\tControl\t6.8\t7.5\t0.18\tLate
 Day 7\t7.8\t0.61\tTreatment A\t7.4\t8.1\t0.041\tLate
 Day 7\t8.4\t0.66\tTreatment B\t8.0\t8.8\t0.006\tLate
 Day 7\t9.0\t0.72\tTreatment C\t8.6\t9.4\t0.0007\tLate`,
-  line: `time\tvalue\tsd\tsem\tseries
-0\t1.0\t0.12\t0.05\tControl
-1\t1.3\t0.16\t0.07\tControl
-2\t1.6\t0.18\t0.08\tControl
-3\t1.8\t0.21\t0.09\tControl
-0\t1.0\t0.14\t0.06\tTreatment
-1\t2.1\t0.24\t0.11\tTreatment
-2\t3.5\t0.31\t0.14\tTreatment
-3\t4.4\t0.38\t0.17\tTreatment`,
+  line: `time\tvalue\tsd\tsem\tn\tseries
+0\t1.0\t0.12\t0.069\t3\tControl
+1\t1.3\t0.16\t0.092\t3\tControl
+2\t1.6\t0.18\t0.104\t3\tControl
+3\t1.8\t0.21\t0.121\t3\tControl
+0\t1.0\t0.14\t0.081\t3\tTreatment
+1\t2.1\t0.24\t0.139\t3\tTreatment
+2\t3.5\t0.31\t0.179\t3\tTreatment
+3\t4.4\t0.38\t0.219\t3\tTreatment`,
   lineNoError: `time\tvalue\tseries
 0\t1.0\tControl
 1\t1.3\tControl
@@ -2160,18 +2164,19 @@ const plotDefinitionSeeds: PlotDefinition[] = [
     name: "Line",
     family: "Trend",
     summary: "Time-course or ordered trend with multiple series and visible markers.",
-    inputHint: "One row per ordered estimate. Map an optional non-negative SD, SEM, or 95% CI half-width column and display it as bars or a ribbon.",
+    inputHint: "One row per ordered estimate. Map SD or SEM plus sample size to calculate reference-series Welch tests at each X value, or display uncertainty without testing.",
     roles: [
       { key: "x", label: "X", kind: "number", required: true },
       { key: "value", label: "Value", kind: "number", required: true },
       { key: "error", label: "Uncertainty half-width (SD / SEM / 95% CI)", kind: "number", required: false },
+      { key: "n", label: "Sample size (n)", kind: "number", required: false },
       { key: "series", label: "Series", kind: "category", required: false },
     ],
-    defaultMapping: { x: "time", value: "value", error: "sd", series: "series" },
+    defaultMapping: { x: "time", value: "value", error: "sd", n: "n", series: "series" },
     sampleData: samples.line,
     examples: [
-      { label: "Example 1", description: "Ordered means with SD and SEM columns.", data: samples.line, mapping: { x: "time", value: "value", error: "sd", series: "series" } },
-      { label: "Example 2", description: "Ordered observations without an error column.", data: samples.lineNoError, mapping: { x: "time", value: "value", error: "", series: "series" } },
+      { label: "Example 1", description: "Ordered means with SD, SEM, and explicit sample size for optional Welch tests.", data: samples.line, mapping: { x: "time", value: "value", error: "sd", n: "n", series: "series" } },
+      { label: "Example 2", description: "Ordered estimates without uncertainty or significance calculation.", data: samples.lineNoError, mapping: { x: "time", value: "value", error: "", n: "", series: "series" } },
     ],
   },
   {
@@ -3037,9 +3042,9 @@ const plotGuidanceSeeds: Record<PlotType, PlotGuidance> = {
     references: [plotReferences.visualizationHistory, plotReferences.graphicalPerception, plotReferences.errorBars],
   },
   line: {
-    definition: "按 X 的自然顺序连接相邻估计值，以位置和线段方向编码连续变化；可将预先计算的 SD、SEM 或 95% CI 半宽显示为逐点误差棒或连续不确定性带。",
-    suitableData: "具有自然顺序的时间、剂量或阶段数据；每行应是一个估计值，若显示不确定性还需对应的非负半宽。带状区域不会自动把 SD 或 SEM 变成置信区间。",
-    answers: "指标随顺序如何变化，不同序列的方向、速度或响应模式是否不同，以及已给定的不确定性范围有多大。",
+    definition: "按实际 X 采样值的自然顺序连接相邻估计值，以位置和线段方向编码连续变化；可将预先计算的 SD、SEM 或 95% CI 半宽显示为逐点误差棒或连续不确定性带。",
+    suitableData: "具有自然顺序的时间、剂量或阶段数据；每行应是一个估计值。若计算逐时间点显著性，必须提供均值、SD 或 SEM、显式样本量 n 和分组，并明确数据不是配对或重复测量。",
+    answers: "指标随顺序如何变化，不同序列的方向、速度或响应模式是否不同，以及已给定的不确定性范围有多大。可选 Welch 检验只回答各时间点相对参考组的独立样本差异，不检验整体时间×组交互。",
     origin: "Playfair 同样在 1786 年用时间序列折线展示贸易变化，使“随时间阅读趋势”成为统计图形的核心用途。",
     references: [plotReferences.visualizationHistory, plotReferences.graphicalPerception, plotReferences.errorBars],
   },
@@ -3485,7 +3490,7 @@ const commonSettingKeys: Array<keyof VisualizationSettings> = [
 const hiddenLegendIds = new Set<PlotType>(["box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "heatmap", "clustered-heatmap", "correlation-heatmap", "venn", "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos", "manhattan", "qq", "chromosome-ideogram", "snp-density", "genome-tracks", "waterfall", "oncoplot", "motif-logo", "treemap", "funnel", "precision-recall", "calibration", "decision-curve", "nomogram", "lasso-path", "km-cutoff", "risk-score", "go-circle", "kegg-circle", "go-chord", "pathway-impact", "nes-fdr", "multi-gsea", "enrichment-ridge", "sankey-bubble", "geographic-map", "petal", "word-cloud"]);
 const specializedSettingKeys: Partial<Record<PlotType, Array<keyof VisualizationSettings>>> = {
   bar: ["swapAxes", "barErrorType", "barVariant", "barInputMode", "barOverlayType", "secondaryAxisLabel", "showSignificance", "significanceThreshold", "axisBreakStart", "axisBreakEnd", "barGap", "barBorderWidth", "barBorderColor", "errorBarLineWidth", "errorBarCapSize"],
-  line: ["swapAxes", "showPoints", "lineErrorType", "lineUncertaintyStyle", "lineBandOpacity", "errorBarLineWidth", "errorBarCapSize"],
+  line: ["swapAxes", "showPoints", "lineErrorType", "lineUncertaintyStyle", "lineBandOpacity", "showSignificance", "significanceThreshold", "lineReferenceSeries", "linePAdjustment", "errorBarLineWidth", "errorBarCapSize"],
   scatter: ["swapAxes", "showLabels", "correlationMethod", "associationVariant", "associationFit", "associationPolynomialDegree", "associationLoessSpan", "associationShowConfidenceBand", "associationShowPValue", "associationGroupMode", "associationHexbinSize", "associationDensityBandwidth"],
   correlation: ["showLabels", "correlationMethod", "associationVariant", "associationFit", "associationPolynomialDegree", "associationLoessSpan", "associationShowConfidenceBand", "associationShowPValue", "associationGroupMode", "associationHexbinSize", "associationDensityBandwidth"],
   pca: ["swapAxes", "showLabels", "ordinationView", "ordinationShowEllipse", "ordinationShowHull", "ordinationShowCentroids", "ordinationShowLoadings", "ordinationLoadingCount", "ordinationUseShapes", "ordinationPermanovaR2", "ordinationPermanovaP", "ordinationPermanovaPermutations", "ordinationMethodNote"],
@@ -4725,6 +4730,24 @@ export function validatePlotDataset(
       }).length;
       if (negativeErrors > 0) errors.push(`Error magnitude contains ${negativeErrors} negative value${negativeErrors === 1 ? "" : "s"}; SD and SEM must be non-negative, as must all uncertainty half-widths.`);
     }
+    if (definition.id === "line" && settings?.showSignificance) {
+      if (settings.lineErrorType !== "sd" && settings.lineErrorType !== "sem") errors.push("Line significance calculation requires Mean ± SD or Mean ± SEM.");
+      if (!mapping.n) errors.push("Map an explicit sample-size (n) column before calculating line significance.");
+      if (!mapping.series) errors.push("Map a series column before calculating line significance.");
+      if (mapping.n) {
+        const invalidSampleSizes = dataset.rows.filter((row) => {
+          const sampleSize = parseNumericValue(row[mapping.n]);
+          return sampleSize === null || !Number.isInteger(sampleSize) || sampleSize < 2;
+        }).length;
+        if (invalidSampleSizes > 0) errors.push(`Sample size contains ${invalidSampleSizes} invalid value${invalidSampleSizes === 1 ? "" : "s"}; Welch tests require an integer n ≥ 2 for every estimate.`);
+      }
+      if (mapping.x && mapping.series) {
+        const duplicatePairs = dataset.rows.map((row) => `${row[mapping.x]}\u0000${row[mapping.series] || "All"}`);
+        if (new Set(duplicatePairs).size !== duplicatePairs.length) errors.push("Summary-mode line significance requires exactly one mean per X and series pair.");
+        const series = [...new Set(dataset.rows.map((row) => row[mapping.series]).filter(Boolean))];
+        if (series.length < 2) errors.push("Line significance calculation requires at least two series.");
+      }
+    }
   }
 
   if ((definition.id === "scatter" || definition.id === "correlation") && settings) {
@@ -5753,6 +5776,84 @@ export function numericExtent(values: number[], includeZero = false): [number, n
   }
   const padding = (maximum - minimum) * 0.08;
   return [minimum - padding, maximum + padding];
+}
+
+/** Prefer the actual ordered sampling values for compact time-course axes. */
+export function observedAxisTicks(values: number[], maximumCount: number) {
+  const ticks = [...new Set(values.filter(Number.isFinite))].sort((a, b) => a - b);
+  return ticks.length >= 2 && ticks.length <= Math.max(2, maximumCount) ? ticks : undefined;
+}
+
+function logGamma(value: number): number {
+  const coefficients = [676.5203681218851, -1259.1392167224028, 771.3234287776531, -176.6150291621406, 12.507343278686905, -0.13857109526572012, 9.984369578019572e-6, 1.5056327351493116e-7];
+  if (value < 0.5) return Math.log(Math.PI) - Math.log(Math.sin(Math.PI * value)) - logGamma(1 - value);
+  const shifted = value - 1;
+  let series = 0.9999999999998099;
+  coefficients.forEach((coefficient, index) => { series += coefficient / (shifted + index + 1); });
+  const t = shifted + coefficients.length - 0.5;
+  return 0.5 * Math.log(2 * Math.PI) + (shifted + 0.5) * Math.log(t) - t + Math.log(series);
+}
+
+function betaContinuedFraction(a: number, b: number, x: number) {
+  const maximumIterations = 200;
+  const epsilon = 3e-12;
+  const floor = 1e-300;
+  const qab = a + b; const qap = a + 1; const qam = a - 1;
+  let c = 1; let d = 1 - qab * x / qap;
+  if (Math.abs(d) < floor) d = floor;
+  d = 1 / d;
+  let result = d;
+  for (let iteration = 1; iteration <= maximumIterations; iteration += 1) {
+    const twice = 2 * iteration;
+    let aa = iteration * (b - iteration) * x / ((qam + twice) * (a + twice));
+    d = 1 + aa * d; if (Math.abs(d) < floor) d = floor;
+    c = 1 + aa / c; if (Math.abs(c) < floor) c = floor;
+    d = 1 / d; result *= d * c;
+    aa = -(a + iteration) * (qab + iteration) * x / ((a + twice) * (qap + twice));
+    d = 1 + aa * d; if (Math.abs(d) < floor) d = floor;
+    c = 1 + aa / c; if (Math.abs(c) < floor) c = floor;
+    d = 1 / d;
+    const delta = d * c; result *= delta;
+    if (Math.abs(delta - 1) < epsilon) break;
+  }
+  return result;
+}
+
+function regularizedIncompleteBeta(x: number, a: number, b: number) {
+  if (x <= 0) return 0;
+  if (x >= 1) return 1;
+  const front = Math.exp(logGamma(a + b) - logGamma(a) - logGamma(b) + a * Math.log(x) + b * Math.log(1 - x));
+  return x < (a + 1) / (a + b + 2)
+    ? front * betaContinuedFraction(a, b, x) / a
+    : 1 - front * betaContinuedFraction(b, a, 1 - x) / b;
+}
+
+export function studentTTwoSidedPValue(tStatistic: number, degreesOfFreedom: number) {
+  if (!Number.isFinite(tStatistic) || !Number.isFinite(degreesOfFreedom) || degreesOfFreedom <= 0) return null;
+  const squared = tStatistic * tStatistic;
+  return Math.min(1, Math.max(0, regularizedIncompleteBeta(degreesOfFreedom / (degreesOfFreedom + squared), degreesOfFreedom / 2, 0.5)));
+}
+
+export function welchSummaryPValue(meanA: number, sdA: number, nA: number, meanB: number, sdB: number, nB: number) {
+  if (![meanA, sdA, nA, meanB, sdB, nB].every(Number.isFinite) || sdA < 0 || sdB < 0 || nA < 2 || nB < 2) return null;
+  const varianceA = sdA * sdA / nA;
+  const varianceB = sdB * sdB / nB;
+  const variance = varianceA + varianceB;
+  if (variance === 0) return meanA === meanB ? 1 : 0;
+  const degreesOfFreedom = variance * variance / (varianceA * varianceA / (nA - 1) + varianceB * varianceB / (nB - 1));
+  return studentTTwoSidedPValue(Math.abs(meanA - meanB) / Math.sqrt(variance), degreesOfFreedom);
+}
+
+export function benjaminiHochbergAdjust(pValues: number[]) {
+  const indexed = pValues.map((pValue, index) => ({ pValue: Math.min(1, Math.max(0, pValue)), index })).sort((a, b) => a.pValue - b.pValue);
+  const adjusted = Array<number>(pValues.length).fill(1);
+  let runningMinimum = 1;
+  for (let rankIndex = indexed.length - 1; rankIndex >= 0; rankIndex -= 1) {
+    const entry = indexed[rankIndex];
+    runningMinimum = Math.min(runningMinimum, entry.pValue * indexed.length / (rankIndex + 1));
+    adjusted[entry.index] = Math.min(1, runningMinimum);
+  }
+  return adjusted;
 }
 
 export function resolveAxisDomain(

--- a/tests/e2e/visualization-studio.spec.ts
+++ b/tests/e2e/visualization-studio.spec.ts
@@ -56,6 +56,44 @@ siFBN2-9706\t0.07\t0.04\tFBN2`);
     expect(source).toContain("H596");
   });
 
+  test("uses actual time points and calculates adjusted line significance", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop-chromium", "Desktop line-statistics regression");
+    await page.goto("/");
+    await page.getByRole("button", { name: /^Line/ }).click();
+    await page.getByRole("textbox", { name: "CSV or TSV data" }).fill(`time\tvalue\tsd\tsem\tn\tseries
+0\t0.2292416667\t0.0456901316\t0.0263792098\t3\tMock
+1\t0.2277416667\t0.0061745614\t0.0035648847\t3\tMock
+2\t0.6077083333\t0.0611888828\t0.0353274179\t3\tMock
+3\t0.9141\t0.1925812994\t0.1111868650\t3\tMock
+0\t0.2025666667\t0.0125768637\t0.0072612556\t3\tNC
+1\t0.2676833333\t0.0132398074\t0.0076440064\t3\tNC
+2\t0.6331333333\t0.0476931795\t0.0275356700\t3\tNC
+3\t1.0819666667\t0.0700105810\t0.0404206278\t3\tNC
+0\t0.196475\t0.0145138368\t0.0083795676\t3\tsiFBN2-1224
+1\t0.217675\t0.0182540464\t0.0105389786\t3\tsiFBN2-1224
+2\t0.43765\t0.0376459687\t0.0217349102\t3\tsiFBN2-1224
+3\t0.6097083333\t0.0203331984\t0.0117393776\t3\tsiFBN2-1224
+0\t0.1690416667\t0.0026113933\t0.0015076886\t3\tsiFBN2-9706
+1\t0.2015083333\t0.0251189296\t0.0145024208\t3\tsiFBN2-9706
+2\t0.420225\t0.0086766329\t0.0050094563\t3\tsiFBN2-9706
+3\t0.7469583333\t0.0106625024\t0.0061559987\t3\tsiFBN2-9706`);
+    await page.getByRole("button", { name: "Auto-map" }).click();
+    await page.getByRole("combobox", { name: "Error representation" }).selectOption("sd");
+
+    const svg = page.locator("svg[aria-label='Line scientific figure preview']");
+    await expect(svg.locator("[data-axis-tick='x']")).toHaveText(["0", "1", "2", "3"]);
+    await expect(svg.locator("[data-axis-label='x']")).toHaveCount(0);
+    await expect(svg.locator("[data-axis-label='y']")).toHaveCount(0);
+
+    await page.getByRole("checkbox", { name: "Calculate significance" }).check({ force: true });
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    await page.getByRole("combobox", { name: "Reference series" }).selectOption("Mock");
+    const annotations = svg.locator("[data-plot-element='line-significance']");
+    await expect(annotations).toHaveCount(12);
+    const adjusted = await annotations.evaluateAll((elements) => elements.map((element) => Number(element.getAttribute("data-adjusted-p"))));
+    expect(adjusted.every((value) => Number.isFinite(value) && value >= 0 && value <= 1)).toBe(true);
+  });
+
   test("selects, resets, remaps, adjusts, and exports a representative plot", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "desktop-chromium", "Desktop interaction baseline");
     await page.goto("/");


### PR DESCRIPTION
Closes #36

## Summary
- display supplied time values on compact line-chart axes instead of interpolated domain ticks
- keep blank X/Y axis labels blank
- add optional pointwise Welch tests versus a selected reference series from mean + SD/SEM + explicit n
- support Benjamini-Hochberg adjustment and show `*`, `**`, `***`, or `ns`
- validate summary-statistic assumptions and document repeated-measures limitations

## Verification
- `npm run verify` (188 unit tests, lint, typecheck, production build)
- `npm run test:e2e` (full suite passed; platform-specific cases skipped as designed)
- exact supplied 0/1/2/3 line dataset covered by desktop browser regression