### PR TITLE
Brighten all built-in scientific palettes

### DIFF
--- a/src/lib/release-contract.test.tsx
+++ b/src/lib/release-contract.test.tsx
@@ -39,15 +39,15 @@ describe("Visualization Studio release contract", () => {
     });
   });
 
-  it("locks the compact publication defaults and restrained Chinese-traditional palette", () => {
+  it("locks the compact publication defaults and brighter Chinese-traditional palette", () => {
     expect(defaultVisualizationSettings).toMatchObject({
       width: 340,
       height: 340,
       fontFamily: "arial",
-      categoricalColors: ["#8A6F58", "#355F61", "#C99573", "#71877C"],
-      divergingLow: "#9AADB0",
+      categoricalColors: ["#9D8673", "#55797A", "#CEA081", "#7F9389"],
+      divergingLow: "#9CAEB1",
       divergingMid: "#FAF8F4",
-      divergingHigh: "#D5B49E",
+      divergingHigh: "#D6B5A0",
     });
     expect(defaultVisualizationPaletteSeriesId).toBe("chinese-traditional");
     expect(defaultVisualizationThemeId).toBe("cn-beihai");

--- a/src/lib/visualization-studio.test.ts
+++ b/src/lib/visualization-studio.test.ts
@@ -6,6 +6,7 @@ import {
   analysisProvenanceForPlot,
   categoricalColorForIndex,
   boxStatistics,
+  brightenScientificPaletteColor,
   confidenceInterval95,
   compactLegendLabel,
   covarianceEllipsePoints,
@@ -745,6 +746,8 @@ describe("Visualization Studio data contracts", () => {
       expect(colors.every((color) => /^#[0-9A-F]{6}$/i.test(color))).toBe(true);
       expect(Math.abs(relativeLuminance(theme.sequential[0]) - relativeLuminance(theme.sequential[1]))).toBeGreaterThan(theme.series === "chinese-traditional" ? 0.25 : 0.35);
       expect(relativeLuminance(theme.diverging[1])).toBeGreaterThan(Math.max(relativeLuminance(theme.diverging[0]), relativeLuminance(theme.diverging[2])));
+      expect(theme.categorical.reduce((sum, color) => sum + relativeLuminance(color), 0) / theme.categorical.length).toBeGreaterThan(0.18);
+      expect(theme.categorical.every((color) => relativeLuminance(color) > 0.085)).toBe(true);
     });
     Object.values(journalThemes).filter((theme) => theme.series === "chinese-traditional").forEach((theme) => {
       expect(relativeLuminance(theme.diverging[1])).toBeGreaterThan(0.85);
@@ -753,6 +756,12 @@ describe("Visualization Studio data contracts", () => {
       expect(rgbChroma(theme.diverging[0])).toBeLessThan(0.3);
       expect(rgbChroma(theme.diverging[2])).toBeLessThan(0.3);
     });
+  });
+
+  it("brightens built-in plot colors without changing user-supplied invalid values", () => {
+    expect(brightenScientificPaletteColor("#315C86")).toBe("#527699");
+    expect(relativeLuminance(brightenScientificPaletteColor("#355F61"))).toBeGreaterThan(relativeLuminance("#355F61"));
+    expect(brightenScientificPaletteColor("custom-color")).toBe("custom-color");
   });
 
   it("keeps minimal palettes within a single restrained hue family", () => {
@@ -768,7 +777,7 @@ describe("Visualization Studio data contracts", () => {
     });
   });
 
-  it("uses recalibrated low-saturation Chinese-traditional palettes", () => {
+  it("uses brighter low-saturation Chinese-traditional palettes", () => {
     Object.values(journalThemes).filter((theme) => theme.series === "chinese-traditional").forEach((theme) => {
       expect(theme.categorical.every((color) => rgbChroma(color) < 0.48)).toBe(true);
     });

--- a/src/lib/visualization-studio.ts
+++ b/src/lib/visualization-studio.ts
@@ -237,6 +237,38 @@ export type JournalTheme = {
   grid: string;
 };
 
+/**
+ * Lift built-in scientific colors for white figure canvases without changing hue order.
+ * Dark colors receive the largest correction, while already-light colors only move slightly.
+ * Custom user colors intentionally bypass this calibration.
+ */
+export function brightenScientificPaletteColor(hex: string, strength = 1) {
+  const normalized = hex.replace("#", "");
+  if (!/^[0-9A-F]{6}$/i.test(normalized)) return hex;
+  const channels = [0, 2, 4].map((start) => Number.parseInt(normalized.slice(start, start + 2), 16));
+  const perceivedLightness = 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+  const baseLift = perceivedLightness < 82 ? 0.22 : perceivedLightness < 122 ? 0.16 : perceivedLightness < 166 ? 0.1 : 0.04;
+  const lift = Math.max(0, Math.min(1, baseLift * strength));
+  return `#${channels.map((channel) => Math.round(channel + (255 - channel) * lift).toString(16).padStart(2, "0")).join("")}`.toUpperCase();
+}
+
+function brightenScientificPalette(colors: string[], strength = 1) {
+  return colors.map((color) => brightenScientificPaletteColor(color, strength));
+}
+
+function calibrateBuiltInJournalTheme(theme: JournalTheme): JournalTheme {
+  return {
+    ...theme,
+    categorical: brightenScientificPalette(theme.categorical),
+    sequential: [theme.sequential[0], brightenScientificPaletteColor(theme.sequential[1], 0.72)],
+    diverging: [
+      brightenScientificPaletteColor(theme.diverging[0], 0.45),
+      theme.diverging[1],
+      brightenScientificPaletteColor(theme.diverging[2], 0.45),
+    ],
+  };
+}
+
 export function analysisProvenanceForPlot(
   type: PlotType,
   settings: VisualizationSettings,
@@ -578,12 +610,12 @@ export const defaultVisualizationSettings: VisualizationSettings = {
   radarFillOpacity: 0.16,
   radialMaximum: null,
   pyramidDisplayMode: "value",
-  categoricalColors: ["#8A6F58", "#355F61", "#C99573", "#71877C"],
+  categoricalColors: brightenScientificPalette(["#8A6F58", "#355F61", "#C99573", "#71877C"]),
   continuousLow: "#E9D8CB",
-  continuousHigh: "#355F61",
-  divergingLow: "#9AADB0",
+  continuousHigh: brightenScientificPaletteColor("#355F61", 0.72),
+  divergingLow: brightenScientificPaletteColor("#9AADB0", 0.45),
   divergingMid: "#FAF8F4",
-  divergingHigh: "#D5B49E",
+  divergingHigh: brightenScientificPaletteColor("#D5B49E", 0.45),
 };
 
 export type OrdinationType = "pca" | "pcoa" | "umap" | "tsne" | "nmds";
@@ -1041,7 +1073,7 @@ export function ordinationLoadingLayout(
   return { frame, ...domains, originX, originY, fontSize, safetyScale, geometries, minimumArrowLength };
 }
 
-export const journalThemes: Record<JournalThemeId, JournalTheme> = {
+const journalThemeSeeds: Record<JournalThemeId, JournalTheme> = {
   "minimal-ink": {
     id: "minimal-ink",
     series: "minimal",
@@ -1319,6 +1351,10 @@ export const journalThemes: Record<JournalThemeId, JournalTheme> = {
     grid: "#F1E7E5",
   },
 };
+
+export const journalThemes = Object.fromEntries(
+  Object.entries(journalThemeSeeds).map(([id, theme]) => [id, calibrateBuiltInJournalTheme(theme)]),
+) as Record<JournalThemeId, JournalTheme>;
 
 function buildUmapExample() {
   const clusters = [

--- a/tests/e2e/visualization-studio.spec.ts
+++ b/tests/e2e/visualization-studio.spec.ts
@@ -251,7 +251,7 @@ siFBN2-9706\t0.07\t0.04\tFBN2`);
     await page.getByRole("button", { name: "墨蓝", exact: true }).click();
     const bars = page.locator("svg[aria-label='Bar scientific figure preview'] [data-plot-element='bar']");
     await expect(bars).toHaveCount(8);
-    expect(await bars.evaluateAll((marks) => marks.slice(0, 4).map((mark) => mark.getAttribute("fill")))).toEqual(["#315C86", "#526E88", "#70849A", "#8F9DAC"]);
+    expect(await bars.evaluateAll((marks) => marks.slice(0, 4).map((mark) => mark.getAttribute("fill")))).toEqual(["#527699", "#6E859B", "#7E90A4", "#9AA7B4"]);
   });
 
   test("keeps the desktop workbench aligned and brings a distant selection fully into view", async ({ page }, testInfo) => {


### PR DESCRIPTION
Closes #38

## Changes
- adds a centralized white-canvas lightness calibration for all built-in themes
- brightens categorical colors most strongly, sequential heatmap endpoints moderately, and diverging endpoints gently
- preserves theme IDs, black semantic text, custom colors, plotting logic, and export behavior
- updates release, luminance, and browser contracts

## Verification
- `npm run verify`: 12 files / 189 tests, lint, typecheck, production build
- Playwright palette/mobile regression: 3 passed, 3 expected project skips
- Impeccable detector: `[]`