### PR TITLE
Add design-aware Bar statistical analysis

### DIFF
--- a/src/components/VisualizationStudio.tsx
+++ b/src/components/VisualizationStudio.tsx
@@ -10,12 +10,14 @@ import { Card, CardBody, CardHeader } from "@/components/ui/Card";
 import { cn } from "@/lib/cn";
 import { analyzeExpressionMatrix, defaultPcaOptions, type PcaDataLayer, type PcaOptions } from "@/lib/visualization-pca";
 import { analyzeSetIntersections, intersectionExportTsv } from "@/lib/visualization-sets";
+import { analyzeBarData, barAnalysisResultsTsv } from "@/lib/visualization-bar-analysis";
 import {
   defaultVisualizationPaletteSeriesId,
   defaultVisualizationSettings,
   defaultVisualizationThemeId,
   activeNumericAxes,
   analysisProvenanceForPlot,
+  categoricalColorForIndex,
   figureFontPresets,
   getPlotDefinition,
   getPlotModule,
@@ -552,6 +554,28 @@ export function VisualizationStudio() {
   const invalidYLimits = manualAxes.includes("y") && settings.yMin !== null && settings.yMax !== null && settings.yMin >= settings.yMax;
   const pcaAnalysis = useMemo(() => plotType === "pca" && pcaInputMode === "matrix" ? analyzeExpressionMatrix(rawData, pcaOptions, pcaObservationMetadata) : null, [plotType, pcaInputMode, rawData, pcaObservationMetadata, pcaOptions]);
   const dataset = useMemo(() => pcaAnalysis?.dataset ?? parseDelimitedData(rawData), [pcaAnalysis, rawData]);
+  const barCategoryOptions = useMemo(() => plotType === "bar" && mapping.category
+    ? [...new Set(dataset.rows.map((row) => row[mapping.category]).filter(Boolean))]
+    : [], [dataset.rows, mapping.category, plotType]);
+  const barAnalysis = useMemo(() => plotType === "bar" ? analyzeBarData(dataset.rows, mapping, {
+    mode: settings.barAnalysisMode,
+    referenceCategory: settings.barReferenceCategory || barCategoryOptions[0],
+    adjustment: settings.barPAdjustment,
+  }) : null, [barCategoryOptions, dataset.rows, mapping, plotType, settings.barAnalysisMode, settings.barPAdjustment, settings.barReferenceCategory]);
+  const displayDataset = useMemo(() => barAnalysis ? {
+    ...dataset,
+    headers: barAnalysis.pValueColumn && !dataset.headers.includes(barAnalysis.pValueColumn)
+      ? [...dataset.headers, barAnalysis.pValueColumn]
+      : dataset.headers,
+    rows: barAnalysis.rows,
+  } : dataset, [barAnalysis, dataset]);
+  const displayMapping = useMemo(() => plotType === "bar" ? {
+    ...mapping,
+    error: settings.barInputMode === "summary" && settings.barErrorType !== "none"
+      ? mapping[settings.barErrorType] || mapping.error
+      : mapping.error,
+    pValue: barAnalysis?.pValueColumn ?? mapping.pValue,
+  } : mapping, [barAnalysis?.pValueColumn, mapping, plotType, settings.barErrorType, settings.barInputMode]);
   const lineSeriesOptions = useMemo(() => plotType === "line" && mapping.series
     ? [...new Set(dataset.rows.map((row) => row[mapping.series]).filter(Boolean))]
     : [], [dataset.rows, mapping.series, plotType]);
@@ -570,11 +594,12 @@ export function VisualizationStudio() {
     const low = Math.min(...values); const high = Math.max(...values); const span = Math.max(1, high - low, Math.abs(low) * .2, Math.abs(high) * .2);
     return { minimum: Math.floor(low - span * .25), maximum: Math.ceil(high + span * .25), step: Math.max(0.01, Number((span / 200).toPrecision(2))) };
   }, [dataset.rows, mapping.value, plotType]);
-  const validation = useMemo(
-    () => validatePlotDataset(getPlotDefinition(plotType), dataset, mapping, settings),
-    [plotType, dataset, mapping, settings],
-  );
-  const categoryLabels = useMemo(() => categoricalColorLabels(plotType, dataset.rows, mapping), [plotType, dataset.rows, mapping]);
+  const validation = useMemo(() => {
+    const base = validatePlotDataset(getPlotDefinition(plotType), displayDataset, displayMapping, settings);
+    if (!barAnalysis) return base;
+    return { errors: [...base.errors, ...barAnalysis.errors], warnings: [...base.warnings, ...barAnalysis.warnings] };
+  }, [barAnalysis, displayDataset, displayMapping, plotType, settings]);
+  const categoryLabels = useMemo(() => categoricalColorLabels(plotType, displayDataset.rows, displayMapping), [displayDataset.rows, displayMapping, plotType]);
   const analysisProvenance = useMemo(() => analysisProvenanceForPlot(plotType, settings, pcaInputMode), [pcaInputMode, plotType, settings]);
   const isValid = validation.errors.length === 0;
   const mainGridStyle = {
@@ -590,18 +615,20 @@ export function VisualizationStudio() {
   }, [paletteSeriesId, selectedCustomPalette, themeId]);
   const currentPaletteName = paletteSeriesId === "custom" ? selectedCustomPalette?.name || "Custom" : journalThemes[themeId].name;
   const currentPalettePreviewColors = paletteColorsFromSettings(settings, themeId).categoricalColors.slice(0, 4);
+  const effectiveCategoricalColors = useMemo(() => categoryLabels.map((_, index) => categoricalColorForIndex(index, settings.categoricalColors)), [categoryLabels, settings.categoricalColors]);
   const hasUnsavedColorChanges = currentColorFingerprint !== selectedPaletteFingerprint;
+  const colorResolvedSettings = useMemo(() => effectiveCategoricalColors.length ? { ...settings, categoricalColors: effectiveCategoricalColors } : settings, [effectiveCategoricalColors, settings]);
   const previewSettings = useMemo(() => {
-    if (!pcaAnalysis) return settings;
-    if (settings.ordinationView === "scree") return settings;
+    if (!pcaAnalysis) return colorResolvedSettings;
+    if (settings.ordinationView === "scree") return colorResolvedSettings;
     const displayedX = settings.swapAxes ? mapping.y : mapping.x;
     const displayedY = settings.swapAxes ? mapping.x : mapping.y;
     return {
-      ...settings,
+      ...colorResolvedSettings,
       xLabel: settings.xLabel || pcaAxisLabel(displayedX, pcaAnalysis.explainedVariance),
       yLabel: settings.yLabel || pcaAxisLabel(displayedY, pcaAnalysis.explainedVariance),
     };
-  }, [mapping.x, mapping.y, pcaAnalysis, settings]);
+  }, [colorResolvedSettings, mapping.x, mapping.y, pcaAnalysis, settings.ordinationView, settings.swapAxes, settings.xLabel, settings.yLabel]);
 
   const updateSetting = <Key extends keyof VisualizationSettings>(key: Key, value: VisualizationSettings[Key]) => {
     setSettings((current) => ({ ...current, [key]: value }));
@@ -611,7 +638,7 @@ export function VisualizationStudio() {
     setSettings((current) => {
       const themeColors = journalThemes[themeId].categorical;
       const nextLength = Math.max(current.categoricalColors.length, index + 1);
-      const categoricalColors = Array.from({ length: nextLength }, (_, colorIndex) => current.categoricalColors[colorIndex] ?? themeColors[colorIndex % themeColors.length]);
+      const categoricalColors = Array.from({ length: nextLength }, (_, colorIndex) => current.categoricalColors[colorIndex] ?? categoricalColorForIndex(colorIndex, themeColors));
       categoricalColors[index] = value;
       return { ...current, categoricalColors };
     });
@@ -633,7 +660,7 @@ export function VisualizationStudio() {
       setPcaOptions(defaultPcaOptions);
       if (nextInputMode === "scores") setSettings((current) => ({ ...current, ordinationView: "scores", ordinationShowLoadings: false }));
     }
-    if (plotType === "bar") updateSetting("barInputMode", exampleIndex === 1 ? "long" : "summary");
+    if (plotType === "bar" && !example.settings?.barInputMode) updateSetting("barInputMode", exampleIndex === 1 ? "long" : "summary");
     if (plotType === "roc") updateSetting("rocInputMode", exampleIndex === 1 ? "precomputed-time" : "raw");
     if (plotType === "venn" || plotType === "upset") updateSetting("setInputMode", exampleIndex === 1 ? "peak-overlap" : "membership");
     if (example.settings) setSettings((current) => ({ ...current, ...example.settings as Partial<VisualizationSettings> }));
@@ -673,6 +700,7 @@ export function VisualizationStudio() {
       compositionLabelMode: nextType === "rose" ? "value" : current.compositionLabelMode,
       setInputMode: (nextType === "venn" || nextType === "upset") ? "membership" : current.setInputMode,
       rocInputMode: nextType === "roc" ? "raw" : current.rocInputMode,
+      ...(nextExample.settings ?? {}),
       legendPosition: (["heatmap", "clustered-heatmap", "correlation-heatmap", "enrichment", "enrichment-bar", "venn", "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos"] as PlotType[]).includes(nextType) && current.legendPosition === "bottom" ? "right" : current.legendPosition,
     }, nextType));
     window.requestAnimationFrame(() => {
@@ -773,6 +801,16 @@ export function VisualizationStudio() {
     }));
   };
 
+  const selectBarAnalysisMode = (mode: VisualizationSettings["barAnalysisMode"]) => {
+    setSettings((current) => ({
+      ...current,
+      barAnalysisMode: mode,
+      barInputMode: ["raw-independent", "raw-paired", "qpcr-delta-ct"].includes(mode) ? "long" : "summary",
+      showSignificance: mode !== "none",
+      barReferenceCategory: current.barReferenceCategory || barCategoryOptions[0] || "",
+    }));
+  };
+
   const selectAssociationVariant = (value: VisualizationSettings["associationVariant"]) => {
     setSettings((current) => ({
       ...current,
@@ -820,6 +858,12 @@ export function VisualizationStudio() {
     downloadBlob(new Blob([content], { type: "text/tab-separated-values;charset=utf-8" }), `${slug(definition.name)}-${slug(label)}-exact-members.tsv`);
   };
 
+  const downloadBarAnalysis = () => {
+    if (!barAnalysis?.results.length) return;
+    const content = barAnalysisResultsTsv(barAnalysis.results);
+    downloadBlob(new Blob([content], { type: "text/tab-separated-values;charset=utf-8" }), "bar-statistical-results.tsv");
+  };
+
   const exportSvg = () => {
     if (!svgRef.current || !isValid) return;
     const source = serializeSvg(svgRef.current, figureFontPresets[settings.fontFamily].family);
@@ -860,7 +904,7 @@ export function VisualizationStudio() {
       plotType,
       themeId,
       mapping,
-      settings,
+      settings: previewSettings,
       analysisProvenance: analysisProvenance ?? undefined,
       pca: plotType === "pca" ? {
         inputMode: pcaInputMode,
@@ -997,11 +1041,20 @@ export function VisualizationStudio() {
               ) : (
                 <div className="overflow-auto rounded-[8px] border border-[var(--ln-vis-panel-border)] bg-[var(--ln-vis-canvas-bg)] p-2 sm:p-3">
                   <div className="mx-auto w-fit min-w-max max-w-none rounded-[4px] bg-white shadow-[0_1px_6px_rgba(35,36,42,0.08)]">
-                    <ScientificChartPreview svgRef={svgRef} type={plotType} dataset={dataset} mapping={mapping} settings={previewSettings} themeId={themeId} />
+                    <ScientificChartPreview svgRef={svgRef} type={plotType} dataset={displayDataset} mapping={displayMapping} settings={previewSettings} themeId={themeId} />
                   </div>
                 </div>
               )}
               {validation.warnings.length > 0 ? <div className="mt-3 rounded-[8px] border border-warning/20 bg-warning-surface px-3 py-2 text-xs leading-5 text-warning">{validation.warnings.join(" · ")}</div> : null}
+              {plotType === "bar" && isValid && barAnalysis?.results.length ? <details className="mt-3 overflow-hidden rounded-[8px] border border-hairline bg-white">
+                <summary className="focus-ring flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 text-xs font-semibold text-ink"><span>Statistical results · {barAnalysis.results.length} comparison{barAnalysis.results.length === 1 ? "" : "s"}</span><Button type="button" size="sm" onClick={(event) => { event.preventDefault(); downloadBarAnalysis(); }}><Download className="h-3.5 w-3.5" aria-hidden />TSV</Button></summary>
+                <div className="overflow-x-auto border-t border-hairline">
+                  <table className="min-w-full text-left text-[11px] text-graphite">
+                    <thead className="bg-stone text-[10px] uppercase tracking-[0.04em] text-muted"><tr><th className="px-3 py-2">Group</th><th className="px-3 py-2">Comparison</th><th className="px-3 py-2">Difference (95% CI)</th><th className="px-3 py-2">n</th><th className="px-3 py-2">P raw</th><th className="px-3 py-2">P adjusted</th><th className="px-3 py-2">Method / scale</th></tr></thead>
+                    <tbody>{barAnalysis.results.map((result) => <tr key={`${result.facet}-${result.group}-${result.reference}-${result.comparison}`} className="border-t border-hairline first:border-t-0"><td className="whitespace-nowrap px-3 py-2">{result.group}</td><td className="whitespace-nowrap px-3 py-2">{result.comparison} vs {result.reference}</td><td className="whitespace-nowrap px-3 py-2 font-mono">{result.difference.toPrecision(4)} ({result.lower95.toPrecision(4)}, {result.upper95.toPrecision(4)})</td><td className="whitespace-nowrap px-3 py-2">{result.nComparison} / {result.nReference}</td><td className="whitespace-nowrap px-3 py-2 font-mono">{result.rawPValue.toPrecision(3)}</td><td className="whitespace-nowrap px-3 py-2 font-mono">{result.adjustedPValue.toPrecision(3)}</td><td className="whitespace-nowrap px-3 py-2">{result.method} · {result.analysisScale}</td></tr>)}</tbody>
+                  </table>
+                </div>
+              </details> : null}
             </CardBody>
           </Card>
           </div>
@@ -1194,9 +1247,24 @@ export function VisualizationStudio() {
                 {settings.barVariant === "dual-axis" ? <p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">The secondary column uses an independently labelled right-side scale. Use only when the two units are explicit and a shared baseline would be misleading.</p> : null}
                 {settings.barVariant === "overlay" ? <p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">The secondary column shares the primary value axis and should use the same unit.</p> : null}
                 {settings.barVariant === "axis-break" ? <><RangeControl label="Break start" value={settings.axisBreakStart} minimum={barBreakRange.minimum} maximum={barBreakRange.maximum} step={barBreakRange.step} onChange={(value) => updateSetting("axisBreakStart", value)} /><RangeControl label="Break end" value={settings.axisBreakEnd} minimum={barBreakRange.minimum} maximum={barBreakRange.maximum} step={barBreakRange.step} onChange={(value) => updateSetting("axisBreakEnd", value)} /></> : null}
-                {settings.barVariant !== "polar" ? <ToggleControl label="Significance annotations" checked={settings.showSignificance} onChange={(value) => updateSetting("showSignificance", value)} /> : null}
-                {settings.showSignificance && settings.barVariant !== "polar" ? <RangeControl label="P-value threshold" value={settings.significanceThreshold} minimum={0.001} maximum={0.1} step={0.001} onChange={(value) => updateSetting("significanceThreshold", value)} /> : null}
               </ControlGroup>
+              {settings.barVariant !== "polar" ? <ControlGroup title="Statistical analysis">
+                <SelectControl label="Analysis source / design" value={settings.barAnalysisMode} onChange={(value) => selectBarAnalysisMode(value as VisualizationSettings["barAnalysisMode"])}>
+                  <option value="none">Visualization only · no P values</option>
+                  <option value="supplied">Display supplied P values</option>
+                  <option value="raw-independent">Raw independent observations · Welch</option>
+                  <option value="summary-independent">Mean + SD/SEM + n · Welch</option>
+                  <option value="raw-paired">Raw matched observations · paired t</option>
+                  <option value="qpcr-delta-ct">qPCR · display relative expression, test ΔCt</option>
+                </SelectControl>
+                {!["none", "supplied"].includes(settings.barAnalysisMode) ? <>
+                  <SelectControl label="Reference category" value={settings.barReferenceCategory || barCategoryOptions[0] || ""} onChange={(value) => updateSetting("barReferenceCategory", value)}>{barCategoryOptions.map((category) => <option key={category} value={category}>{category}</option>)}</SelectControl>
+                  <SelectControl label="Multiple-testing correction" value={settings.barPAdjustment} onChange={(value) => updateSetting("barPAdjustment", value as VisualizationSettings["barPAdjustment"])}><option value="bh">Benjamini–Hochberg FDR</option><option value="holm">Holm family-wise correction</option><option value="none">None</option></SelectControl>
+                </> : null}
+                {settings.barAnalysisMode !== "none" ? <ToggleControl label="Significance annotations" checked={settings.showSignificance} onChange={(value) => updateSetting("showSignificance", value)} /> : null}
+                {settings.showSignificance ? <RangeControl label={settings.barPAdjustment === "none" || settings.barAnalysisMode === "supplied" ? "P-value threshold" : "Adjusted P threshold"} value={settings.significanceThreshold} minimum={0.001} maximum={0.1} step={0.001} onChange={(value) => updateSetting("significanceThreshold", value)} /> : null}
+                <p className="rounded-[8px] bg-stone px-3 py-2 text-[11px] leading-4 text-graphite">Independent modes use two-sided Welch t-tests within each group/facet. Summary inference requires explicit integer n ≥ 2 and SD or SEM; n is never inferred. Paired mode requires the same subject IDs in both categories. qPCR displays relative expression but tests biological-replicate ΔCt. Technical replicates must be aggregated before import.</p>
+              </ControlGroup> : null}
               {settings.barVariant !== "polar" ? <ControlGroup title="Bar appearance"><RangeControl label="Border width" value={settings.barBorderWidth} minimum={0} maximum={3} step={0.1} unit=" px" onChange={(value) => updateSetting("barBorderWidth", value)} />{settings.barBorderWidth > 0 ? <ColorControl label="Border color" value={settings.barBorderColor} onChange={(value) => updateSetting("barBorderColor", value)} /> : null}<p className="text-[11px] leading-4 text-muted">Set the width to 0 for borderless bars. The outline remains fully opaque so it stays legible when fill opacity is reduced.</p></ControlGroup> : null}
             </> : null}
 
@@ -1320,7 +1388,7 @@ export function VisualizationStudio() {
             </ControlGroup> : null}
 
               <ControlGroup title="Editable colors">
-                {categoryLabels.map((label, index) => <ColorControl key={`${label}-${index}`} label={`${index + 1} · ${label}`} value={settings.categoricalColors[index] ?? journalThemes[themeId].categorical[index % journalThemes[themeId].categorical.length]} onChange={(value) => updateCategoryColor(index, value)} />)}
+                {categoryLabels.map((label, index) => <ColorControl key={`${label}-${index}`} label={`${index + 1} · ${label}`} value={effectiveCategoricalColors[index] ?? categoricalColorForIndex(index, journalThemes[themeId].categorical)} onChange={(value) => updateCategoryColor(index, value)} />)}
                 {(["enrichment", "enrichment-bar", "go-circle", "kegg-circle", "pathway-impact", "nes-fdr"] as PlotType[]).includes(plotType) || ((plotType === "heatmap" || plotType === "clustered-heatmap") && settings.heatmapScale === "none" && settings.heatmapColorMode === "sequential") ? <><ColorControl label="Sequential low" value={settings.continuousLow} onChange={(value) => updateSetting("continuousLow", value)} /><ColorControl label="Sequential high" value={settings.continuousHigh} onChange={(value) => updateSetting("continuousHigh", value)} /></> : null}
                 {(["heatmap", "clustered-heatmap", "correlation-heatmap"] as PlotType[]).includes(plotType) && (plotType === "correlation-heatmap" || settings.heatmapScale !== "none" || settings.heatmapColorMode === "diverging") ? <><ColorControl label="Diverging low" value={settings.divergingLow} onChange={(value) => updateSetting("divergingLow", value)} /><ColorControl label="Midpoint" value={settings.divergingMid} onChange={(value) => updateSetting("divergingMid", value)} /><ColorControl label="Diverging high" value={settings.divergingHigh} onChange={(value) => updateSetting("divergingHigh", value)} /></> : null}
               </ControlGroup>

--- a/src/lib/visualization-bar-analysis.test.ts
+++ b/src/lib/visualization-bar-analysis.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { adjustPValues, analyzeBarData, barAnalysisResultsTsv } from "./visualization-bar-analysis";
+
+describe("Bar statistical analysis", () => {
+  it("calculates a two-sided Welch comparison from independent biological observations", () => {
+    const rows = [1, 2, 3].map((value, index) => ({ category: "Control", value: String(value), sample_id: `C${index + 1}` }))
+      .concat([4, 5, 6].map((value, index) => ({ category: "Treatment", value: String(value), sample_id: `T${index + 1}` })));
+    const analysis = analyzeBarData(rows, { category: "category", value: "value", subject: "sample_id" }, { mode: "raw-independent", adjustment: "none", referenceCategory: "Control" });
+    expect(analysis.errors).toEqual([]);
+    expect(analysis.results).toHaveLength(1);
+    expect(analysis.results[0].difference).toBeCloseTo(3, 10);
+    expect(analysis.results[0].statistic).toBeCloseTo(3.674234614, 8);
+    expect(analysis.results[0].degreesOfFreedom).toBeCloseTo(4, 10);
+    expect(analysis.results[0].rawPValue).toBeCloseTo(0.021311641, 8);
+    expect(analysis.results[0].lower95).toBeCloseTo(0.733042, 5);
+    expect(analysis.results[0].upper95).toBeCloseTo(5.266958, 5);
+  });
+
+  it("uses explicit n with SD for summary-data inference and never infers n from SEM", () => {
+    const complete = analyzeBarData([
+      { category: "Control", mean: "1", sd: "1", sem: "0.5", n: "4" },
+      { category: "Treatment", mean: "3", sd: "1.5", sem: "0.75", n: "4" },
+    ], { category: "category", value: "mean", sd: "sd", sem: "sem", n: "n" }, { mode: "summary-independent", adjustment: "none", referenceCategory: "Control" });
+    expect(complete.errors).toEqual([]);
+    expect(complete.results[0].nReference).toBe(4);
+    expect(complete.results[0].method).toBe("Welch two-sample t-test");
+
+    const missingN = analyzeBarData([
+      { category: "Control", mean: "1", sd: "1", sem: "0.5" },
+      { category: "Treatment", mean: "3", sd: "1.5", sem: "0.75" },
+    ], { category: "category", value: "mean", sd: "sd", sem: "sem" }, { mode: "summary-independent", adjustment: "none" });
+    expect(missingN.errors.some((message) => message.includes("sample-size"))).toBe(true);
+  });
+
+  it("matches paired subjects and rejects incomplete pairs", () => {
+    const pairedRows = [
+      { category: "Before", value: "1", subject: "P1" }, { category: "After", value: "2", subject: "P1" },
+      { category: "Before", value: "2", subject: "P2" }, { category: "After", value: "4", subject: "P2" },
+      { category: "Before", value: "4", subject: "P3" }, { category: "After", value: "7", subject: "P3" },
+    ];
+    const analysis = analyzeBarData(pairedRows, { category: "category", value: "value", subject: "subject" }, { mode: "raw-paired", adjustment: "none", referenceCategory: "Before" });
+    expect(analysis.errors).toEqual([]);
+    expect(analysis.results[0].difference).toBeCloseTo(2, 10);
+    expect(analysis.results[0].statistic).toBeCloseTo(3.464101615, 8);
+    expect(analysis.results[0].degreesOfFreedom).toBe(2);
+    expect(analysis.results[0].rawPValue).toBeCloseTo(0.0741799, 6);
+
+    const incomplete = analyzeBarData(pairedRows.slice(0, -1), { category: "category", value: "value", subject: "subject" }, { mode: "raw-paired", adjustment: "none", referenceCategory: "Before" });
+    expect(incomplete.errors.some((message) => message.includes("same subject IDs"))).toBe(true);
+  });
+
+  it("tests qPCR on delta Ct while preserving relative expression for display", () => {
+    const rows = [
+      { category: "Control", relative_expression: "1.00", delta_ct: "4.0", sample_id: "C1" },
+      { category: "Control", relative_expression: "1.05", delta_ct: "4.2", sample_id: "C2" },
+      { category: "Treatment", relative_expression: "2.10", delta_ct: "3.0", sample_id: "T1" },
+      { category: "Treatment", relative_expression: "1.95", delta_ct: "3.2", sample_id: "T2" },
+    ];
+    const analysis = analyzeBarData(rows, { category: "category", value: "relative_expression", analysisValue: "delta_ct", subject: "sample_id" }, { mode: "qpcr-delta-ct", adjustment: "none", referenceCategory: "Control" });
+    expect(analysis.errors).toEqual([]);
+    expect(analysis.results[0].meanReference).toBeCloseTo(4.1, 10);
+    expect(analysis.results[0].meanComparison).toBeCloseTo(3.1, 10);
+    expect(analysis.results[0].analysisScale).toBe("ΔCt");
+    expect(analysis.rows[0].relative_expression).toBe("1.00");
+  });
+
+  it("adjusts the displayed comparison family with Holm or Benjamini-Hochberg", () => {
+    expect(adjustPValues([0.01, 0.04, 0.03], "holm")).toEqual([0.03, 0.06, 0.06]);
+    expect(adjustPValues([0.01, 0.04, 0.03], "bh")).toEqual([0.03, 0.04, 0.04]);
+  });
+
+  it("exports complete audit columns", () => {
+    const analysis = analyzeBarData([
+      { category: "A", value: "1", sample: "A1" }, { category: "A", value: "2", sample: "A2" },
+      { category: "B", value: "3", sample: "B1" }, { category: "B", value: "4", sample: "B2" },
+    ], { category: "category", value: "value", subject: "sample" }, { mode: "raw-independent", adjustment: "bh" });
+    const tsv = barAnalysisResultsTsv(analysis.results);
+    expect(tsv).toContain("p_raw\tp_adjusted\tmethod\tanalysis_scale");
+    expect(tsv).toContain("Welch two-sample t-test");
+  });
+
+  it("rejects duplicated biological IDs instead of counting technical replicates as n", () => {
+    const analysis = analyzeBarData([
+      { category: "A", value: "1", sample: "S1" }, { category: "A", value: "1.1", sample: "S1" },
+      { category: "B", value: "2", sample: "S2" }, { category: "B", value: "2.1", sample: "S3" },
+    ], { category: "category", value: "value", subject: "sample" }, { mode: "raw-independent", adjustment: "none" });
+    expect(analysis.errors.some((message) => message.includes("aggregate technical replicates"))).toBe(true);
+  });
+});

--- a/src/lib/visualization-bar-analysis.ts
+++ b/src/lib/visualization-bar-analysis.ts
@@ -1,0 +1,374 @@
+import { regularizedIncompleteBeta } from "./visualization-advanced";
+
+export type BarAnalysisMode = "none" | "supplied" | "raw-independent" | "summary-independent" | "raw-paired" | "qpcr-delta-ct";
+export type BarPAdjustment = "none" | "holm" | "bh";
+
+export type BarAnalysisMapping = {
+  category?: string;
+  value?: string;
+  group?: string;
+  facet?: string;
+  pValue?: string;
+  sd?: string;
+  sem?: string;
+  n?: string;
+  subject?: string;
+  analysisValue?: string;
+};
+
+export type BarComparisonResult = {
+  facet: string;
+  group: string;
+  reference: string;
+  comparison: string;
+  nReference: number;
+  nComparison: number;
+  meanReference: number;
+  meanComparison: number;
+  difference: number;
+  lower95: number;
+  upper95: number;
+  statistic: number;
+  degreesOfFreedom: number;
+  rawPValue: number;
+  adjustedPValue: number;
+  method: "Welch two-sample t-test" | "Paired t-test";
+  analysisScale: string;
+};
+
+export type BarAnalysisResult<Row extends Record<string, string> = Record<string, string>> = {
+  rows: Row[];
+  pValueColumn: string | null;
+  results: BarComparisonResult[];
+  errors: string[];
+  warnings: string[];
+};
+
+export type BarAnalysisOptions = {
+  mode: BarAnalysisMode;
+  referenceCategory?: string;
+  adjustment: BarPAdjustment;
+};
+
+const computedPValueColumn = "__bar_adjusted_p_value";
+type Summary = { mean: number; sd: number; n: number };
+type Unit<Row> = { facet: string; group: string; rows: Row[] };
+
+function numeric(value: string | undefined) {
+  if (value === undefined || value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function sampleSummary(values: number[]): Summary {
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance = values.length > 1
+    ? values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / (values.length - 1)
+    : Number.NaN;
+  return { mean, sd: Math.sqrt(variance), n: values.length };
+}
+
+function twoSidedStudentP(statistic: number, degreesOfFreedom: number) {
+  if (!Number.isFinite(degreesOfFreedom) || degreesOfFreedom <= 0) return Number.NaN;
+  if (!Number.isFinite(statistic)) return statistic === 0 ? 1 : 0;
+  const squared = statistic ** 2;
+  return Math.max(0, Math.min(1, regularizedIncompleteBeta(
+    degreesOfFreedom / (degreesOfFreedom + squared),
+    degreesOfFreedom / 2,
+    0.5,
+  )));
+}
+
+function criticalT95(degreesOfFreedom: number) {
+  let lower = 0;
+  let upper = 64;
+  for (let iteration = 0; iteration < 80; iteration += 1) {
+    const midpoint = (lower + upper) / 2;
+    if (twoSidedStudentP(midpoint, degreesOfFreedom) > 0.05) lower = midpoint;
+    else upper = midpoint;
+  }
+  return (lower + upper) / 2;
+}
+
+function welchComparison(reference: Summary, comparison: Summary) {
+  const referenceVariance = reference.sd ** 2 / reference.n;
+  const comparisonVariance = comparison.sd ** 2 / comparison.n;
+  const standardErrorSquared = referenceVariance + comparisonVariance;
+  const standardError = Math.sqrt(standardErrorSquared);
+  const difference = comparison.mean - reference.mean;
+  if (standardError === 0) {
+    return {
+      difference,
+      lower95: difference,
+      upper95: difference,
+      statistic: difference === 0 ? 0 : Math.sign(difference) * Number.POSITIVE_INFINITY,
+      degreesOfFreedom: reference.n + comparison.n - 2,
+      pValue: difference === 0 ? 1 : 0,
+    };
+  }
+  const denominator = referenceVariance ** 2 / (reference.n - 1) + comparisonVariance ** 2 / (comparison.n - 1);
+  const degreesOfFreedom = standardErrorSquared ** 2 / denominator;
+  const statistic = difference / standardError;
+  const margin = criticalT95(degreesOfFreedom) * standardError;
+  return {
+    difference,
+    lower95: difference - margin,
+    upper95: difference + margin,
+    statistic,
+    degreesOfFreedom,
+    pValue: twoSidedStudentP(statistic, degreesOfFreedom),
+  };
+}
+
+function pairedComparison(referenceValues: number[], comparisonValues: number[]) {
+  const summary = sampleSummary(comparisonValues.map((value, index) => value - referenceValues[index]));
+  const standardError = summary.sd / Math.sqrt(summary.n);
+  if (standardError === 0) {
+    return {
+      difference: summary.mean,
+      lower95: summary.mean,
+      upper95: summary.mean,
+      statistic: summary.mean === 0 ? 0 : Math.sign(summary.mean) * Number.POSITIVE_INFINITY,
+      degreesOfFreedom: summary.n - 1,
+      pValue: summary.mean === 0 ? 1 : 0,
+    };
+  }
+  const degreesOfFreedom = summary.n - 1;
+  const statistic = summary.mean / standardError;
+  const margin = criticalT95(degreesOfFreedom) * standardError;
+  return {
+    difference: summary.mean,
+    lower95: summary.mean - margin,
+    upper95: summary.mean + margin,
+    statistic,
+    degreesOfFreedom,
+    pValue: twoSidedStudentP(statistic, degreesOfFreedom),
+  };
+}
+
+export function adjustPValues(values: number[], method: BarPAdjustment) {
+  if (method === "none") return [...values];
+  const indexed = values.map((value, index) => ({ value, index })).sort((left, right) => left.value - right.value);
+  const adjusted = Array(values.length).fill(Number.NaN) as number[];
+  if (method === "holm") {
+    let runningMaximum = 0;
+    indexed.forEach((entry, rank) => {
+      runningMaximum = Math.max(runningMaximum, Math.min(1, entry.value * (values.length - rank)));
+      adjusted[entry.index] = runningMaximum;
+    });
+    return adjusted;
+  }
+  let runningMinimum = 1;
+  for (let rank = indexed.length - 1; rank >= 0; rank -= 1) {
+    const entry = indexed[rank];
+    runningMinimum = Math.min(runningMinimum, entry.value * values.length / (rank + 1));
+    adjusted[entry.index] = Math.min(1, runningMinimum);
+  }
+  return adjusted;
+}
+
+function unitKey(row: Record<string, string>, mapping: BarAnalysisMapping) {
+  const facet = mapping.facet ? row[mapping.facet] || "All facets" : "All facets";
+  const group = mapping.group ? row[mapping.group] || "All groups" : "All groups";
+  return `${facet}\u0000${group}`;
+}
+
+function resultKey(facet: string, group: string, category: string) {
+  return `${facet}\u0000${group}\u0000${category}`;
+}
+
+function groupRows<Row extends Record<string, string>>(rows: Row[], mapping: BarAnalysisMapping): Unit<Row>[] {
+  const units = new Map<string, Unit<Row>>();
+  rows.forEach((row) => {
+    const key = unitKey(row, mapping);
+    const [facet, group] = key.split("\u0000");
+    const unit = units.get(key) ?? { facet, group, rows: [] };
+    unit.rows.push(row);
+    units.set(key, unit);
+  });
+  return [...units.values()];
+}
+
+function requireMapping(mapping: BarAnalysisMapping, key: keyof BarAnalysisMapping, label: string, errors: string[]) {
+  const column = mapping[key];
+  if (!column) errors.push(`Map ${label} before running Bar statistical analysis.`);
+  return column ?? "";
+}
+
+function context(unit: Unit<Record<string, string>>) {
+  return `facet “${unit.facet}”, group “${unit.group}”`;
+}
+
+export function analyzeBarData<Row extends Record<string, string>>(
+  sourceRows: Row[],
+  mapping: BarAnalysisMapping,
+  options: BarAnalysisOptions,
+): BarAnalysisResult<Row> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  if (options.mode === "none") return { rows: sourceRows, pValueColumn: null, results: [], errors, warnings };
+  if (options.mode === "supplied") {
+    if (!mapping.pValue) errors.push("Map a supplied P value column before displaying significance annotations.");
+    return { rows: sourceRows, pValueColumn: mapping.pValue ?? null, results: [], errors, warnings };
+  }
+
+  const categoryColumn = requireMapping(mapping, "category", "a category column", errors);
+  const valueColumn = requireMapping(mapping, "value", "a display value column", errors);
+  const subjectColumn = ["raw-independent", "raw-paired", "qpcr-delta-ct"].includes(options.mode)
+    ? requireMapping(mapping, "subject", "a biological sample / subject ID column", errors)
+    : "";
+  const analysisColumn = options.mode === "qpcr-delta-ct"
+    ? requireMapping(mapping, "analysisValue", "a ΔCt analysis column", errors)
+    : valueColumn;
+  if (options.mode === "summary-independent") requireMapping(mapping, "n", "an explicit sample-size (n) column", errors);
+  if (errors.length > 0) return { rows: sourceRows, pValueColumn: null, results: [], errors, warnings };
+
+  const rawResults: BarComparisonResult[] = [];
+  for (const unit of groupRows(sourceRows, mapping)) {
+    const categories = [...new Set(unit.rows.map((row) => row[categoryColumn]).filter(Boolean))];
+    if (categories.length < 2) continue;
+    const reference = options.referenceCategory && categories.includes(options.referenceCategory)
+      ? options.referenceCategory
+      : categories[0];
+    if (options.referenceCategory && !categories.includes(options.referenceCategory)) {
+      warnings.push(`${context(unit)} does not contain reference “${options.referenceCategory}”; its first category “${reference}” was used.`);
+    }
+    const referenceRows = unit.rows.filter((row) => row[categoryColumn] === reference);
+
+    for (const comparison of categories.filter((category) => category !== reference)) {
+      const comparisonRows = unit.rows.filter((row) => row[categoryColumn] === comparison);
+      let referenceSummary: Summary;
+      let comparisonSummary: Summary;
+      let computed: ReturnType<typeof welchComparison> | ReturnType<typeof pairedComparison>;
+      let method: BarComparisonResult["method"];
+
+      if (options.mode === "summary-independent") {
+        if (referenceRows.length !== 1 || comparisonRows.length !== 1) {
+          errors.push(`${context(unit)} requires exactly one summary row for “${reference}” and “${comparison}”.`);
+          continue;
+        }
+        const toSummary = (row: Row, category: string) => {
+          const mean = numeric(row[valueColumn]);
+          const sampleSize = numeric(row[mapping.n ?? ""]);
+          const sdValue = mapping.sd ? numeric(row[mapping.sd]) : null;
+          const semValue = mapping.sem ? numeric(row[mapping.sem]) : null;
+          if (mean === null) errors.push(`${context(unit)}, category “${category}” has a missing or invalid mean.`);
+          if (sampleSize === null || !Number.isInteger(sampleSize) || sampleSize < 2) {
+            errors.push(`${context(unit)}, category “${category}” requires an explicit integer n ≥ 2.`);
+          }
+          if ((sdValue === null || sdValue < 0) && (semValue === null || semValue < 0)) {
+            errors.push(`${context(unit)}, category “${category}” requires a non-negative SD or SEM.`);
+          }
+          if (mean === null || sampleSize === null || !Number.isInteger(sampleSize) || sampleSize < 2) return null;
+          const sd = sdValue !== null && sdValue >= 0 ? sdValue : (semValue ?? Number.NaN) * Math.sqrt(sampleSize);
+          if (mapping.sd && mapping.sem && sdValue !== null && semValue !== null) {
+            const expectedSem = sdValue / Math.sqrt(sampleSize);
+            if (Math.abs(expectedSem - semValue) > Math.max(1e-8, Math.abs(expectedSem) * 0.02)) {
+              warnings.push(`${context(unit)}, category “${category}” has SD and SEM values inconsistent with n by more than 2%; SD was used.`);
+            }
+          }
+          return { mean, sd, n: sampleSize };
+        };
+        const parsedReference = toSummary(referenceRows[0], reference);
+        const parsedComparison = toSummary(comparisonRows[0], comparison);
+        if (!parsedReference || !parsedComparison || !Number.isFinite(parsedReference.sd) || !Number.isFinite(parsedComparison.sd)) continue;
+        referenceSummary = parsedReference;
+        comparisonSummary = parsedComparison;
+        computed = welchComparison(referenceSummary, comparisonSummary);
+        method = "Welch two-sample t-test";
+      } else {
+        const checkIds = (rows: Row[], category: string) => {
+          const ids = rows.map((row) => row[subjectColumn]).filter(Boolean);
+          if (ids.length !== rows.length) errors.push(`${context(unit)}, category “${category}” has a missing biological sample / subject ID.`);
+          const duplicates = [...new Set(ids.filter((id, index) => ids.indexOf(id) !== index))];
+          if (duplicates.length > 0) {
+            errors.push(`${context(unit)}, category “${category}” repeats ID(s) ${duplicates.join(", ")}; aggregate technical replicates before inference.`);
+          }
+        };
+        checkIds(referenceRows, reference);
+        checkIds(comparisonRows, comparison);
+        const referenceValues = referenceRows.map((row) => numeric(row[analysisColumn]));
+        const comparisonValues = comparisonRows.map((row) => numeric(row[analysisColumn]));
+        if (referenceValues.some((value) => value === null) || comparisonValues.some((value) => value === null)) {
+          errors.push(`${context(unit)}, comparison “${reference}” versus “${comparison}” contains a missing or invalid analysis value.`);
+          continue;
+        }
+
+        if (options.mode === "raw-paired") {
+          const referenceById = new Map(referenceRows.map((row) => [row[subjectColumn], numeric(row[analysisColumn]) as number]));
+          const comparisonById = new Map(comparisonRows.map((row) => [row[subjectColumn], numeric(row[analysisColumn]) as number]));
+          const referenceIds = [...referenceById.keys()].sort();
+          const comparisonIds = [...comparisonById.keys()].sort();
+          if (referenceIds.join("\u0000") !== comparisonIds.join("\u0000")) {
+            errors.push(`${context(unit)}, paired comparison “${reference}” versus “${comparison}” must contain the same subject IDs; incomplete pairs were not silently dropped.`);
+            continue;
+          }
+          if (referenceIds.length < 2) {
+            errors.push(`${context(unit)}, paired comparison “${reference}” versus “${comparison}” requires at least two complete biological pairs.`);
+            continue;
+          }
+          const pairedReference = referenceIds.map((id) => referenceById.get(id) as number);
+          const pairedValues = referenceIds.map((id) => comparisonById.get(id) as number);
+          referenceSummary = sampleSummary(pairedReference);
+          comparisonSummary = sampleSummary(pairedValues);
+          computed = pairedComparison(pairedReference, pairedValues);
+          method = "Paired t-test";
+        } else {
+          if (referenceValues.length < 2 || comparisonValues.length < 2) {
+            errors.push(`${context(unit)}, comparison “${reference}” versus “${comparison}” requires at least two biological observations per category.`);
+            continue;
+          }
+          referenceSummary = sampleSummary(referenceValues as number[]);
+          comparisonSummary = sampleSummary(comparisonValues as number[]);
+          computed = welchComparison(referenceSummary, comparisonSummary);
+          method = "Welch two-sample t-test";
+        }
+      }
+
+      rawResults.push({
+        facet: unit.facet,
+        group: unit.group,
+        reference,
+        comparison,
+        nReference: referenceSummary.n,
+        nComparison: comparisonSummary.n,
+        meanReference: referenceSummary.mean,
+        meanComparison: comparisonSummary.mean,
+        difference: computed.difference,
+        lower95: computed.lower95,
+        upper95: computed.upper95,
+        statistic: computed.statistic,
+        degreesOfFreedom: computed.degreesOfFreedom,
+        rawPValue: computed.pValue,
+        adjustedPValue: computed.pValue,
+        method,
+        analysisScale: options.mode === "qpcr-delta-ct" ? "ΔCt" : valueColumn,
+      });
+    }
+  }
+
+  const adjusted = adjustPValues(rawResults.map((result) => result.rawPValue), options.adjustment);
+  const results = rawResults.map((result, index) => ({ ...result, adjustedPValue: adjusted[index] }));
+  const pValues = new Map(results.map((result) => [resultKey(result.facet, result.group, result.comparison), result.adjustedPValue]));
+  const rows = sourceRows.map((row) => {
+    const [facet, group] = unitKey(row, mapping).split("\u0000");
+    const pValue = pValues.get(resultKey(facet, group, row[categoryColumn]));
+    return { ...row, [computedPValueColumn]: pValue === undefined ? "" : String(pValue) } as Row;
+  });
+  return { rows, pValueColumn: computedPValueColumn, results, errors, warnings };
+}
+
+function tsvCell(value: string | number) {
+  const text = typeof value === "number" ? (Number.isFinite(value) ? String(value) : "") : value;
+  return /[\t\n\r"]/u.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+export function barAnalysisResultsTsv(results: BarComparisonResult[]) {
+  const headers = ["facet", "group", "reference", "comparison", "n_reference", "n_comparison", "mean_reference", "mean_comparison", "difference", "ci95_lower", "ci95_upper", "t", "df", "p_raw", "p_adjusted", "method", "analysis_scale"];
+  const rows = results.map((result) => [
+    result.facet, result.group, result.reference, result.comparison, result.nReference, result.nComparison,
+    result.meanReference, result.meanComparison, result.difference, result.lower95, result.upper95,
+    result.statistic, result.degreesOfFreedom, result.rawPValue, result.adjustedPValue, result.method, result.analysisScale,
+  ]);
+  return [headers, ...rows].map((row) => row.map(tsvCell).join("\t")).join("\n");
+}

--- a/src/lib/visualization-studio.test.ts
+++ b/src/lib/visualization-studio.test.ts
@@ -175,7 +175,7 @@ describe("Visualization Studio data contracts", () => {
       expect(examples.length).toBeGreaterThan(0);
       expect(examples.every((example) => example.label.startsWith("Example ") && example.data.length > 20)).toBe(true);
     });
-    expect(getPlotExamples(getPlotDefinition("bar"))).toHaveLength(3);
+    expect(getPlotExamples(getPlotDefinition("bar"))).toHaveLength(5);
     expect(getPlotExamples(getPlotDefinition("line"))).toHaveLength(2);
     const pcaExamples = getPlotExamples(getPlotDefinition("pca"));
     expect(pcaExamples).toHaveLength(2);

--- a/src/lib/visualization-studio.ts
+++ b/src/lib/visualization-studio.ts
@@ -242,6 +242,11 @@ export function analysisProvenanceForPlot(
   settings: VisualizationSettings,
   pcaInputMode: "scores" | "matrix" = "scores",
 ): AnalysisProvenance | null {
+  if (type === "bar") return settings.barAnalysisMode === "none"
+    ? null
+    : settings.barAnalysisMode === "supplied"
+      ? { source: "supplied", label: "Supplied", detail: "P values are supplied by an upstream analysis; Studio displays them without recomputing significance." }
+      : { source: "calculated-in-studio", label: "Calculated in Studio", detail: settings.barAnalysisMode === "qpcr-delta-ct" ? "Bar heights summarize relative expression, while two-sided Welch tests are calculated locally on biological-replicate ΔCt values." : "Reference-category comparisons, confidence intervals, and multiple-testing adjustments are calculated locally from the declared Bar design." };
   if (type === "pca") return pcaInputMode === "matrix"
     ? { source: "calculated-in-studio", label: "Calculated in Studio", detail: "PCA scores, explained variance, and loadings are calculated locally from the supplied feature matrix." }
     : { source: "supplied", label: "Supplied", detail: "PCA coordinates are supplied by an upstream analysis; Studio renders them without recomputing PCA." };
@@ -345,6 +350,9 @@ export type VisualizationSettings = {
   barErrorType: "none" | "sd" | "sem";
   barVariant: "grouped" | "stacked" | "percentage" | "horizontal" | "bidirectional" | "faceted" | "polar" | "bullet" | "pyramid" | "axis-break" | "dual-axis" | "overlay";
   barInputMode: "summary" | "long";
+  barAnalysisMode: "none" | "supplied" | "raw-independent" | "summary-independent" | "raw-paired" | "qpcr-delta-ct";
+  barReferenceCategory: string;
+  barPAdjustment: "none" | "holm" | "bh";
   barOverlayType: "line" | "points";
   secondaryAxisLabel: string;
   showSignificance: boolean;
@@ -485,6 +493,9 @@ export const defaultVisualizationSettings: VisualizationSettings = {
   barErrorType: "none",
   barVariant: "grouped",
   barInputMode: "summary",
+  barAnalysisMode: "none",
+  barReferenceCategory: "",
+  barPAdjustment: "bh",
   barOverlayType: "line",
   secondaryAxisLabel: "Secondary value",
   showSignificance: false,
@@ -1561,6 +1572,46 @@ Day 7\t7.2\tControl\tLate
 Day 7\t8.2\tTreatment\tLate
 Day 7\t8.5\tTreatment\tLate
 Day 7\t8.4\tTreatment\tLate`,
+  barRawIndependent: `category\tvalue\tgroup\tsample_id
+Control\t1.02\tGene A\tA-C1
+Control\t0.96\tGene A\tA-C2
+Control\t1.08\tGene A\tA-C3
+Treatment\t1.54\tGene A\tA-T1
+Treatment\t1.63\tGene A\tA-T2
+Treatment\t1.48\tGene A\tA-T3
+Control\t1.01\tGene B\tB-C1
+Control\t0.93\tGene B\tB-C2
+Control\t1.06\tGene B\tB-C3
+Treatment\t0.68\tGene B\tB-T1
+Treatment\t0.74\tGene B\tB-T2
+Treatment\t0.71\tGene B\tB-T3`,
+  barSummaryInference: `category\tvalue\tsd\tsem\tn\tgroup
+Control\t1.02\t0.061\t0.035\t3\tGene A
+Treatment\t1.55\t0.075\t0.043\t3\tGene A
+Control\t1.00\t0.066\t0.038\t3\tGene B
+Treatment\t0.71\t0.030\t0.017\t3\tGene B`,
+  barPaired: `category\tvalue\tgroup\tsubject_id
+Before\t2.1\tMarker A\tP01
+After\t2.8\tMarker A\tP01
+Before\t2.4\tMarker A\tP02
+After\t3.0\tMarker A\tP02
+Before\t2.0\tMarker A\tP03
+After\t2.9\tMarker A\tP03
+Before\t2.5\tMarker A\tP04
+After\t3.1\tMarker A\tP04`,
+  barQpcr: `category\tgroup\tsample_id\tdelta_ct\trelative_expression
+Control\tFBN2\tC01\t6.12\t1.00
+Control\tFBN2\tC02\t6.28\t0.90
+Control\tFBN2\tC03\t6.03\t1.06
+siFBN2\tFBN2\tT01\t8.71\t0.17
+siFBN2\tFBN2\tT02\t8.95\t0.14
+siFBN2\tFBN2\tT03\t8.62\t0.18
+Control\tEGR1\tC04\t4.32\t1.00
+Control\tEGR1\tC05\t4.21\t1.08
+Control\tEGR1\tC06\t4.39\t0.95
+siFBN2\tEGR1\tT04\t4.51\t0.88
+siFBN2\tEGR1\tT05\t4.44\t0.92
+siFBN2\tEGR1\tT06\t4.62\t0.81`,
   barVariants: `category\tvalue\tsd\tgroup\tsecondary\ttarget\tp_value\tfacet
 Day 1\t3.8\t0.31\tControl\t4.0\t4.5\t0.41\tEarly
 Day 1\t4.2\t0.36\tTreatment A\t4.4\t4.8\t0.12\tEarly
@@ -2140,23 +2191,30 @@ const plotDefinitionSeeds: PlotDefinition[] = [
     name: "Bar",
     family: "Comparison",
     summary: "One categorical family for grouped, stacked, radial, target, overlay, and uncertainty comparisons.",
-    inputHint: "Summary mode uses one row per category/group; long-form mode aggregates replicate observations into means and SD/SEM.",
+    inputHint: "Choose a visualization-only, supplied-P, independent raw, summary-statistics, paired, or qPCR ΔCt workflow. Inference requires biological IDs or explicit n.",
     roles: [
       { key: "category", label: "Category", kind: "category", required: true },
       { key: "value", label: "Value", kind: "number", required: true },
       { key: "error", label: "Error magnitude (SD / SEM)", kind: "number", required: false },
+      { key: "sd", label: "Standard deviation (SD)", kind: "number", required: false },
+      { key: "sem", label: "Standard error (SEM)", kind: "number", required: false },
+      { key: "n", label: "Biological sample size (n)", kind: "number", required: false },
+      { key: "subject", label: "Biological sample / subject ID", kind: "label", required: false },
+      { key: "analysisValue", label: "Analysis value (ΔCt)", kind: "number", required: false },
       { key: "group", label: "Group", kind: "category", required: false },
       { key: "secondary", label: "Secondary value", kind: "number", required: false },
       { key: "target", label: "Target value", kind: "number", required: false },
       { key: "pValue", label: "P value", kind: "number", required: false },
       { key: "facet", label: "Facet", kind: "category", required: false },
     ],
-    defaultMapping: { category: "category", value: "value", error: "sd", group: "group", secondary: "secondary", target: "target", pValue: "p_value", facet: "facet" },
+    defaultMapping: { category: "category", value: "value", error: "sd", sd: "sd", sem: "sem", n: "n", subject: "sample_id", analysisValue: "delta_ct", group: "group", secondary: "secondary", target: "target", pValue: "p_value", facet: "facet" },
     sampleData: samples.barVariants,
     examples: [
-      { label: "Example 1", description: "Summary values with uncertainty, secondary values, targets, P values, and facets.", data: samples.barVariants, mapping: { category: "category", value: "value", error: "sd", group: "group", secondary: "secondary", target: "target", pValue: "p_value", facet: "facet" } },
-      { label: "Example 2", description: "Long-form replicate observations; select Long-form observations to calculate means and uncertainty.", data: samples.barLong, mapping: { category: "category", value: "value", error: "", group: "group", secondary: "", target: "", pValue: "", facet: "facet" } },
-      { label: "Example 3", description: "Category counts or proportions without uncertainty.", data: samples.barCount, mapping: { category: "category", value: "value", error: "", group: "group", secondary: "", target: "", pValue: "", facet: "" } },
+      { label: "Example 1", description: "Summary values for visualization; optional upstream P values can be displayed without recalculation.", data: samples.barVariants, mapping: { category: "category", value: "value", error: "sd", sd: "sd", sem: "", n: "", subject: "", analysisValue: "", group: "group", secondary: "secondary", target: "target", pValue: "p_value", facet: "facet" }, settings: { barInputMode: "summary", barAnalysisMode: "none", showSignificance: false } },
+      { label: "Example 2", description: "Independent biological observations; Welch tests compare each category with the reference within each group.", data: samples.barRawIndependent, mapping: { category: "category", value: "value", error: "", sd: "", sem: "", n: "", subject: "sample_id", analysisValue: "", group: "group", secondary: "", target: "", pValue: "", facet: "" }, settings: { barInputMode: "long", barAnalysisMode: "raw-independent", barReferenceCategory: "Control", barPAdjustment: "bh", showSignificance: true, barErrorType: "sem" } },
+      { label: "Example 3", description: "Means with SD or SEM and explicit biological n; inference uses a summary-statistics Welch test.", data: samples.barSummaryInference, mapping: { category: "category", value: "value", error: "sd", sd: "sd", sem: "sem", n: "n", subject: "", analysisValue: "", group: "group", secondary: "", target: "", pValue: "", facet: "" }, settings: { barInputMode: "summary", barAnalysisMode: "summary-independent", barReferenceCategory: "Control", barPAdjustment: "bh", showSignificance: true, barErrorType: "sd" } },
+      { label: "Example 4", description: "Matched observations with exact subject IDs; incomplete pairs block the paired t-test.", data: samples.barPaired, mapping: { category: "category", value: "value", error: "", sd: "", sem: "", n: "", subject: "subject_id", analysisValue: "", group: "group", secondary: "", target: "", pValue: "", facet: "" }, settings: { barInputMode: "long", barAnalysisMode: "raw-paired", barReferenceCategory: "Before", barPAdjustment: "holm", showSignificance: true, barErrorType: "sem" } },
+      { label: "Example 5", description: "qPCR displays relative expression but performs the Welch test on biological-replicate ΔCt values.", data: samples.barQpcr, mapping: { category: "category", value: "relative_expression", error: "", sd: "", sem: "", n: "", subject: "sample_id", analysisValue: "delta_ct", group: "group", secondary: "", target: "", pValue: "", facet: "" }, settings: { barInputMode: "long", barAnalysisMode: "qpcr-delta-ct", barReferenceCategory: "Control", barPAdjustment: "bh", showSignificance: true, barErrorType: "sem" } },
     ],
   },
   {
@@ -3489,7 +3547,7 @@ const commonSettingKeys: Array<keyof VisualizationSettings> = [
 ];
 const hiddenLegendIds = new Set<PlotType>(["box", "violin", "beeswarm", "raincloud", "histogram", "density", "ridge", "heatmap", "clustered-heatmap", "correlation-heatmap", "venn", "upset", "sankey", "alluvial", "chord", "ligand-receptor", "circos", "manhattan", "qq", "chromosome-ideogram", "snp-density", "genome-tracks", "waterfall", "oncoplot", "motif-logo", "treemap", "funnel", "precision-recall", "calibration", "decision-curve", "nomogram", "lasso-path", "km-cutoff", "risk-score", "go-circle", "kegg-circle", "go-chord", "pathway-impact", "nes-fdr", "multi-gsea", "enrichment-ridge", "sankey-bubble", "geographic-map", "petal", "word-cloud"]);
 const specializedSettingKeys: Partial<Record<PlotType, Array<keyof VisualizationSettings>>> = {
-  bar: ["swapAxes", "barErrorType", "barVariant", "barInputMode", "barOverlayType", "secondaryAxisLabel", "showSignificance", "significanceThreshold", "axisBreakStart", "axisBreakEnd", "barGap", "barBorderWidth", "barBorderColor", "errorBarLineWidth", "errorBarCapSize"],
+  bar: ["swapAxes", "barErrorType", "barVariant", "barInputMode", "barAnalysisMode", "barReferenceCategory", "barPAdjustment", "barOverlayType", "secondaryAxisLabel", "showSignificance", "significanceThreshold", "axisBreakStart", "axisBreakEnd", "barGap", "barBorderWidth", "barBorderColor", "errorBarLineWidth", "errorBarCapSize"],
   line: ["swapAxes", "showPoints", "lineErrorType", "lineUncertaintyStyle", "lineBandOpacity", "showSignificance", "significanceThreshold", "lineReferenceSeries", "linePAdjustment", "errorBarLineWidth", "errorBarCapSize"],
   scatter: ["swapAxes", "showLabels", "correlationMethod", "associationVariant", "associationFit", "associationPolynomialDegree", "associationLoessSpan", "associationShowConfidenceBand", "associationShowPValue", "associationGroupMode", "associationHexbinSize", "associationDensityBandwidth"],
   correlation: ["showLabels", "correlationMethod", "associationVariant", "associationFit", "associationPolynomialDegree", "associationLoessSpan", "associationShowConfidenceBand", "associationShowPValue", "associationGroupMode", "associationHexbinSize", "associationDensityBandwidth"],
@@ -3653,7 +3711,10 @@ export function isPlotRoleActive(type: PlotType, roleKey: string, settings: Visu
   if (type !== "bar") return true;
   if (roleKey === "secondary") return ["dual-axis", "overlay"].includes(settings.barVariant);
   if (roleKey === "target") return settings.barVariant === "bullet";
-  if (roleKey === "pValue") return settings.showSignificance && settings.barVariant !== "polar";
+  if (roleKey === "pValue") return settings.showSignificance && settings.barVariant !== "polar" && settings.barAnalysisMode === "supplied";
+  if (roleKey === "sd" || roleKey === "sem" || roleKey === "n") return settings.barAnalysisMode === "summary-independent";
+  if (roleKey === "subject") return ["raw-independent", "raw-paired", "qpcr-delta-ct"].includes(settings.barAnalysisMode);
+  if (roleKey === "analysisValue") return settings.barAnalysisMode === "qpcr-delta-ct";
   if (roleKey === "facet") return settings.barVariant === "faceted";
   if (roleKey === "error") return settings.barErrorType !== "none" && !["stacked", "percentage", "polar"].includes(settings.barVariant);
   return true;
@@ -3935,7 +3996,7 @@ export function parseRatioValue(value: string | undefined) {
 
 const mappingAliases: Record<string, string[]> = {
   category: ["category", "condition", "sample", "name", "term"],
-  value: ["value", "weight", "mean", "expression", "score", "points", "abundance", "count", "variantcount", "density"],
+  value: ["value", "weight", "mean", "relativeexpression", "expression", "score", "points", "abundance", "count", "variantcount", "density"],
   secondary: ["secondary", "secondaryvalue", "comparison", "overlay", "value2"],
   target: ["target", "reference", "goal", "benchmark", "to", "receiver"],
   facet: ["facet", "panel", "stratum", "cohort"],
@@ -3947,6 +4008,10 @@ const mappingAliases: Record<string, string[]> = {
   z: ["z", "pc3", "dim3", "dimension3", "umap3", "tsne3", "nmds3"],
   shape: ["shape", "batch", "cohort", "site", "sex"],
   error: ["error", "sd", "sem", "se", "stderr", "standarddeviation", "standarderror"],
+  sd: ["sd", "standarddeviation"],
+  sem: ["sem", "se", "stderr", "standarderror"],
+  n: ["n", "samplesize", "biologicaln", "replicates"],
+  analysisValue: ["deltact", "delta_ct", "dct", "analysisvalue"],
   label: ["label", "gene", "feature", "id", "name", "study", "sample", "site", "level", "term", "category"],
   effect: ["log2fc", "logfc", "effect", "estimate"],
   pValue: ["padj", "fdr", "adjustedpvalue", "pvalue", "p"],
@@ -4845,11 +4910,13 @@ export function validatePlotDataset(
     if (needsSecondary && !mapping.secondary) errors.push(`${settings.barVariant === "dual-axis" ? "Dual-axis" : "Overlay"} bars require a mapped secondary value column.`);
     if (needsTarget && !mapping.target) errors.push("Bullet charts require a mapped target value column.");
     if (needsFacet && !mapping.facet) errors.push("Faceted bars require a mapped facet column.");
-    if (settings.showSignificance && settings.barVariant !== "polar" && !mapping.pValue) errors.push("Map a P value column before displaying significance annotations.");
+    if (settings.showSignificance && settings.barVariant !== "polar" && settings.barAnalysisMode === "supplied" && !mapping.pValue) errors.push("Map a supplied P value column before displaying significance annotations.");
     if (mapping.pValue && isPlotRoleActive("bar", "pValue", settings)) {
       const invalidP = dataset.rows.filter((row) => {
         const value = parseNumericValue(row[mapping.pValue]);
-        return value === null || value <= 0 || value > 1;
+        const raw = row[mapping.pValue]?.trim();
+        if (!raw) return false;
+        return value === null || value < 0 || value > 1;
       }).length;
       if (invalidP > 0) errors.push(`P value contains ${invalidP} value${invalidP === 1 ? "" : "s"} outside (0, 1].`);
     }

--- a/tests/e2e/visualization-studio.spec.ts
+++ b/tests/e2e/visualization-studio.spec.ts
@@ -12,6 +12,40 @@ async function expectStablePreviewScreenshot(page: Page, locator: Locator, name:
 }
 
 test.describe("Visualization Studio browser acceptance", () => {
+  test("calculates auditable Bar statistics for raw, summary, paired, and qPCR examples", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop-chromium", "Desktop Bar-statistics acceptance");
+    await page.goto("/");
+    await page.getByRole("button", { name: "Example 2" }).click();
+    await expect(page.getByRole("combobox", { name: "Analysis source / design" })).toHaveValue("raw-independent");
+    await expect(page.getByRole("combobox", { name: "Reference category" })).toHaveValue("Control");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    await expect(page.getByText("Statistical results · 2 comparisons")).toBeVisible();
+    await expect(page.locator("svg[aria-label='Bar scientific figure preview'] text[data-plot-label]").filter({ hasText: /\*/ })).toHaveCount(2);
+    await page.getByText("Statistical results · 2 comparisons").click();
+    await expect(page.getByText("Welch two-sample t-test", { exact: false }).first()).toBeVisible();
+    const downloadEvent = page.waitForEvent("download");
+    await page.getByRole("button", { name: "TSV" }).click();
+    const download = await downloadEvent;
+    const results = await readFile((await download.path())!, "utf8");
+    expect(results).toContain("difference\tci95_lower\tci95_upper\tt\tdf\tp_raw\tp_adjusted");
+    expect(results).toContain("Welch two-sample t-test");
+    await page.getByRole("button", { name: "Example 3" }).click();
+    await expect(page.getByRole("combobox", { name: "Analysis source / design" })).toHaveValue("summary-independent");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    await page.getByRole("combobox", { name: "Biological sample size (n)" }).selectOption("");
+    await expect(page.getByText(/explicit sample-size \(n\)/)).toBeVisible();
+    await page.getByRole("button", { name: "Example 4" }).click();
+    await expect(page.getByRole("combobox", { name: "Analysis source / design" })).toHaveValue("raw-paired");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    await page.getByRole("button", { name: "Example 5" }).click();
+    await expect(page.getByRole("combobox", { name: "Analysis source / design" })).toHaveValue("qpcr-delta-ct");
+    await expect(page.getByRole("combobox", { name: "Analysis value (ΔCt)" })).toHaveValue("delta_ct");
+    await expect(page.getByRole("combobox", { name: "Value *" })).toHaveValue("relative_expression");
+    await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+    await page.getByText("Statistical results · 2 comparisons").click();
+    await expect(page.getByText(/Welch two-sample t-test · ΔCt/).first()).toBeVisible();
+  });
+
   test("keeps rotated bar categories clear of the X-axis title", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "desktop-chromium", "Desktop bar-axis geometry regression");
     await page.goto("/");

--- a/tests/e2e/visualization-studio.spec.ts
+++ b/tests/e2e/visualization-studio.spec.ts
@@ -14,7 +14,7 @@ async function expectStablePreviewScreenshot(page: Page, locator: Locator, name:
 test.describe("Visualization Studio browser acceptance", () => {
   test("calculates auditable Bar statistics for raw, summary, paired, and qPCR examples", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "desktop-chromium", "Desktop Bar-statistics acceptance");
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "networkidle" });
     await page.getByRole("button", { name: "Example 2" }).click();
     await expect(page.getByRole("combobox", { name: "Analysis source / design" })).toHaveValue("raw-independent");
     await expect(page.getByRole("combobox", { name: "Reference category" })).toHaveValue("Control");
@@ -48,7 +48,7 @@ test.describe("Visualization Studio browser acceptance", () => {
 
   test("keeps rotated bar categories clear of the X-axis title", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "desktop-chromium", "Desktop bar-axis geometry regression");
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "networkidle" });
 
     await page.getByRole("textbox", { name: "CSV or TSV data" }).fill(`category\tvalue\tsd\tgroup
 Mock\t1.32\t0.76\tMock


### PR DESCRIPTION
Closes #42

## Summary
- add visualization-only, supplied-P, independent raw, summary-statistics, paired, and qPCR ΔCt Bar workflows
- calculate two-sided Welch or paired t-tests with explicit design validation
- support none, Holm, and Benjamini–Hochberg adjustment across displayed comparisons
- export effect difference, 95% CI, t, df, raw/adjusted P, n, method, and analysis scale as TSV
- include five data examples and browser-tested mappings
- synchronize categorical color expansion already present in the LabNest source so every displayed group retains its own editable color

## Scientific safeguards
- n is never inferred from SD/SEM
- biological sample/subject IDs are required for raw inference
- duplicated IDs are rejected so technical replicates are not counted as biological n
- incomplete pairs block paired inference
- qPCR bars display relative expression while inference uses ΔCt

## Verification
- typecheck, lint, production build: passed
- unit/module tests: 196/196 passed
- Playwright: 27 passed, 21 device-gated skips